### PR TITLE
ci: use different automerge approach

### DIFF
--- a/.github/workflows/automerge-release.yml
+++ b/.github/workflows/automerge-release.yml
@@ -19,7 +19,9 @@ jobs:
           app-id: ${{ secrets.RELEASES_APP_ID }}
           private-key: ${{ secrets.RELEASES_APP_PRIVATE_KEY }}
       
-      - name: Automerge Release-Please PR
-        uses: camunda/infra-global-github-actions/teams/infra/pull-request/automerge@1c6cd774501c2210dd7a44bbc938508fffa80a26
-        with:
-          github-token: ${{ steps.app-token.outputs.token }}
+      - name: Enable auto-merge for release PRs
+        run: |
+          gh pr merge --auto --squash release-please--branches--main || true
+        env:
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
+          GH_REPO: ${{ github.repository }}


### PR DESCRIPTION
Uses `gh cli` to directly merge the pr instead of third party action. this might help us bypass the review requirement as the github app is on the bypass list.