### PR TITLE
feat(core): added more pull-through feet

### DIFF
--- a/models/core/presets/connectors.scad
+++ b/models/core/presets/connectors.scad
@@ -95,4 +95,4 @@ module connectors_pull_through_feet(optimal_orientation=false) {
 // connectors_standard(true);
 // connectors_feet(true);
 // connectors_pull_through(true);
-connectors_pull_through_feet(true);
+// connectors_pull_through_feet(true);


### PR DESCRIPTION
The connector preset (pull-through feet) got 2 new ones:
* 3D3WFPy -> pull-through y-axis (additionally to x-axis
* 3D4WFPy -> pull-through y-axis (additionally to x-axis

We need these both additional ones, since the foot creates an asymetry one doesn't have on regular pull-through connectors