### PR TITLE
fix: path for openscad-render.sh

### DIFF
--- a/cmd/setup/install-openscad.sh
+++ b/cmd/setup/install-openscad.sh
@@ -253,7 +253,7 @@ install_openscad_windows() {
 
 # Run smoke test
 smoke_test() {
-    "${SCRIPT_DIR}/openscad-render.sh"
+    "${SCRIPT_DIR}/../test/openscad-render.sh"
 }
 
 # Main function


### PR DESCRIPTION
./cmd/setup/install-openscad.sh --test looks for `openscad-render.sh' in the wrong path.

Before:
$ ./cmd/setup/install-openscad.sh --test
./cmd/setup/install-openscad.sh: line 256: /home/XXX/YYY/homeracker/cmd/setup/openscad-render.sh: No such file or directory