### PR TITLE
fix(core): improve print orientation for bed slingers.

### DIFF
--- a/models/core/lib/connector.scad
+++ b/models/core/lib/connector.scad
@@ -121,7 +121,7 @@ module connector(dimensions=3, directions=6, pull_through_axis="none", is_foot=f
           pull_through_hole(pull_through_axis, is_foot);
         }
       } else if (valid_directions == 4 && valid_dimensions == 2) {
-        rotation = optimal_orientation ? [0,-135,45] : [0,0,0];
+        rotation = optimal_orientation ? [0,-135,0] : [0,0,0];
         rotate(rotation)
         difference() {
           connector_raw(config, is_foot);
@@ -130,7 +130,7 @@ module connector(dimensions=3, directions=6, pull_through_axis="none", is_foot=f
 
       } else {
         // All other cases: simple flat base with chamfered edge
-        rotation = optimal_orientation ? [90,-45,-45] : [0,0,0];
+        rotation = optimal_orientation ? [90,-45,0] : [0,0,0];
         rotate(rotation)
         difference() {
           intersection() {

--- a/models/core/makerworld/connector.scad
+++ b/models/core/makerworld/connector.scad
@@ -147,7 +147,7 @@ module connector(dimensions=3, directions=6, pull_through_axis="none", is_foot=f
           pull_through_hole(pull_through_axis, is_foot);
         }
       } else if (valid_directions == 4 && valid_dimensions == 2) {
-        rotation = optimal_orientation ? [0,-135,45] : [0,0,0];
+        rotation = optimal_orientation ? [0,-135,0] : [0,0,0];
         rotate(rotation)
         difference() {
           connector_raw(config, is_foot);
@@ -156,7 +156,7 @@ module connector(dimensions=3, directions=6, pull_through_axis="none", is_foot=f
 
       } else {
 
-        rotation = optimal_orientation ? [90,-45,-45] : [0,0,0];
+        rotation = optimal_orientation ? [90,-45,0] : [0,0,0];
         rotate(rotation)
         difference() {
           intersection() {

--- a/models/core/makerworld/lockpin.scad
+++ b/models/core/makerworld/lockpin.scad
@@ -147,7 +147,7 @@ module connector(dimensions=3, directions=6, pull_through_axis="none", is_foot=f
           pull_through_hole(pull_through_axis, is_foot);
         }
       } else if (valid_directions == 4 && valid_dimensions == 2) {
-        rotation = optimal_orientation ? [0,-135,45] : [0,0,0];
+        rotation = optimal_orientation ? [0,-135,0] : [0,0,0];
         rotate(rotation)
         difference() {
           connector_raw(config, is_foot);
@@ -156,7 +156,7 @@ module connector(dimensions=3, directions=6, pull_through_axis="none", is_foot=f
 
       } else {
 
-        rotation = optimal_orientation ? [90,-45,-45] : [0,0,0];
+        rotation = optimal_orientation ? [90,-45,0] : [0,0,0];
         rotate(rotation)
         difference() {
           intersection() {

--- a/models/core/makerworld/support.scad
+++ b/models/core/makerworld/support.scad
@@ -149,7 +149,7 @@ module connector(dimensions=3, directions=6, pull_through_axis="none", is_foot=f
           pull_through_hole(pull_through_axis, is_foot);
         }
       } else if (valid_directions == 4 && valid_dimensions == 2) {
-        rotation = optimal_orientation ? [0,-135,45] : [0,0,0];
+        rotation = optimal_orientation ? [0,-135,0] : [0,0,0];
         rotate(rotation)
         difference() {
           connector_raw(config, is_foot);
@@ -158,7 +158,7 @@ module connector(dimensions=3, directions=6, pull_through_axis="none", is_foot=f
 
       } else {
 
-        rotation = optimal_orientation ? [90,-45,-45] : [0,0,0];
+        rotation = optimal_orientation ? [90,-45,0] : [0,0,0];
         rotate(rotation)
         difference() {
           intersection() {


### PR DESCRIPTION
I have rotated the parts in my slicer to improve printing on my bed  slinger.
Bed slingers mostly move the parts in the Y axis and this IMHO improves the stability the part get directly when generated.