### PR TITLE
feat: new rackmount ears that work natively with homeracker

### DIFF
--- a/cmd/scadm/README.md
+++ b/cmd/scadm/README.md
@@ -19,7 +19,30 @@ pip install scadm
 
 ## Quick Start
 
-### 1. Create `scadm.json` in your project root
+```bash
+pip install scadm    # Install scadm
+scadm install        # Install OpenSCAD + libraries (BOSL2, etc.)
+```
+
+That's it. Now open any `.scad` file using the **project-local** OpenSCAD:
+
+```bash
+./bin/openscad/openscad models/core/main.scad
+```
+
+> [!IMPORTANT]
+> You must use the project-local OpenSCAD at `bin/openscad/openscad` (not a system-installed `openscad`).
+> The project-local binary knows where to find the installed libraries. If you use a system OpenSCAD,
+> you'll get errors about missing dependencies (e.g. BOSL2).
+>
+> Alternatively, point any OpenSCAD at the libraries manually:
+> ```bash
+> OPENSCADPATH=./bin/openscad/libraries openscad models/core/main.scad
+> ```
+
+### Setting up a new project
+
+#### 1. Create `scadm.json` in your project root
 
 ```json
 {
@@ -34,7 +57,7 @@ pip install scadm
 }
 ```
 
-### 2. Install OpenSCAD and dependencies
+#### 2. Install OpenSCAD and dependencies
 
 ```bash
 scadm install

--- a/models/flexmount/flexmount.scad
+++ b/models/flexmount/flexmount.scad
@@ -29,12 +29,12 @@ LOCK_PIN_EDGE_DISTANCE=5.5; // mm
 
 /* [Device Measurements] */
 // Width of the device in mm. Will determine how far apart the actual mounts are in width.
-device_width=100; // [20:0.1:500]
+device_width=150; // [20:0.1:500]
  // TODO test for zero cube
 // Depth of the device in mm. Will determine how far apart the actual mounts are in depth.
-device_depth=99; // [54:0.1:400]
+device_depth=120; // [54:0.1:400]
 // Height of the device in mm. Will determine how far apart the actual mounts are in height.
-device_height=25.5; // [10:0.1:400]
+device_height=45.5; // [10:0.1:400]
 
 /* [Bracket] */
 // Defines the bracket thickness on top of the device.


### PR DESCRIPTION
I wanted to be able to mount a traditional rack item without the 10" rack adapter plates.

<img width="781" height="732" alt="image" src="https://github.com/user-attachments/assets/19c5185e-5deb-487b-9b1c-e09c6f77b5fa" />
