### PR TITLE
ci(renovate): switch infra-global-github-actions to semver tags

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -20,6 +20,6 @@ jobs:
           private-key: ${{ secrets.RELEASES_APP_PRIVATE_KEY }}
 
       - name: Handle Release Creation
-        uses: camunda/infra-global-github-actions/teams/infra/pull-request/release@f5807d2242ed5d143402f3ff092901ce920b01d0
+        uses: camunda/infra-global-github-actions/teams/infra/pull-request/release@pull-request-1.0.0
         with:
           github-token: ${{ steps.app-token.outputs.token }}

--- a/.github/workflows/validate-pr-title.yml
+++ b/.github/workflows/validate-pr-title.yml
@@ -13,7 +13,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Validate PR title
-        uses: camunda/infra-global-github-actions/teams/infra/pull-request/validate-title@f5807d2242ed5d143402f3ff092901ce920b01d0
+        uses: camunda/infra-global-github-actions/teams/infra/pull-request/validate-title@pull-request-1.0.0
         with:
           # Keep in sync with .github/config/release-please-config.json changelog-sections
           types: |

--- a/renovate.json5
+++ b/renovate.json5
@@ -86,9 +86,14 @@
       // Since we have a test-suite running (pre-commit), we can safely automerge the following dependencies
       // If checks fail, Renovate will not automerge
       "matchPackageNames": [
-        "camunda/infra-global-github-actions",
         "BelfrySCAD/BOSL2"
       ],
+      "automerge": true
+    },
+    {
+      // infra-global-github-actions uses per-component semver tags (e.g. pull-request-1.0.0)
+      "matchPackageNames": ["camunda/infra-global-github-actions"],
+      "versioning": "regex:^pull-request-(?<major>\\d+)\\.(?<minor>\\d+)\\.(?<patch>\\d+)$",
       "automerge": true
     },
     {


### PR DESCRIPTION
## 📦 What

Switch `camunda/infra-global-github-actions` from commit digest pinning to per-component semver tags.

## 💡 Why

The upstream repo now publishes per-component semver tags (e.g. `pull-request-1.0.0`). Switching from digest pinning means:
- 🔍 Readable version refs instead of opaque SHA digests
- 🤖 Renovate can propose proper semver bumps (patch/minor/major) instead of noisy "update digest" PRs
- 📌 Pinned to `1.0.0` to verify Renovate picks up the `1.0.1` update

## 🔧 How

- Workflow refs: `@f5807d2...` → `@pull-request-1.0.0`
- Renovate: added `versioning: "regex:..."` rule to parse the `pull-request-` prefixed tags as semver
- ⚠️ Local Renovate dry-run can't verify tag lookup (Camunda org SAML restriction) — production Renovate bot will have access