### PR TITLE
fix: remove Customizer section markers from lib files

### DIFF
--- a/models/inception/lib/supportgrid.scad
+++ b/models/inception/lib/supportgrid.scad
@@ -29,7 +29,6 @@ include <BOSL2/std.scad>
 include <supportbin.scad>
 include <../../core/lib/constants.scad>
 
-/* [Hidden] */
 HR_SG_PRIMARY_COLOR = HR_YELLOW;
 
 HR_SG_MOUNTING_AXIS_VERTICAL = 1;

--- a/models/racklink/lib/racklink.scad
+++ b/models/racklink/lib/racklink.scad
@@ -54,7 +54,6 @@ include <BOSL2/std.scad>
 include <../../core/lib/constants.scad>
 include <../../sleeve/lib/sleeve.scad>
 
-/* [Hidden] */
 HR_RL_PRIMARY_COLOR = HR_YELLOW;
 
 module cover_plate(length, distance, debug_colors=false, disable_chamfer=false, anchor=CENTER, orient=UP, spin=0) {


### PR DESCRIPTION
## 📦 What

Remove `/* [Hidden] */` Customizer section markers from lib files:
- `models/racklink/lib/racklink.scad`
- `models/inception/lib/supportgrid.scad`

## 💡 Why

`scadm flatten` rejects library files containing `/* [Section] */` markers — they're Customizer directives that only belong in `parts/` or `makerworld/` entrypoints. This blocks downstream consumers (e.g. homeracker-exclusive) from flattening models that include these libs.

## 🔧 How

No behavior change. The constants previously under `/* [Hidden] */` are still defined — just without the section marker comment.