### PR TITLE
feat(setup-openscad)!: add scadm-requirements input, remove default version

### DIFF
--- a/.github/actions/setup-openscad/README.md
+++ b/.github/actions/setup-openscad/README.md
@@ -51,7 +51,7 @@ steps:
 1. Sets up Python 3.x
 2. Installs system dependencies (`xvfb`, `libglu1-mesa`, `libfuse2`, `libegl1`, `libxcb-cursor0`)
 3. Resolves scadm version from inputs (source > explicit version > requirements file)
-4. Caches `bin/openscad/` keyed on runner OS, resolved scadm version, `scadm.json`, and local source hash (when `scadm-source` is set)
+4. Caches `bin/openscad/` keyed on runner OS, resolved scadm version, `scadm.json`, and `**/constants.py` under `scadm-source` (when set)
 5. Installs [scadm](../../../cmd/scadm/README.md) — pinned from PyPI, or from a local path if `scadm-source` is set
 6. Runs `scadm install` to download OpenSCAD and libraries
 
@@ -60,5 +60,5 @@ steps:
 This action is independently versioned via [release-please](https://github.com/googleapis/release-please). Use a pinned tag:
 
 ```yaml
-uses: kellerlabs/homeracker/.github/actions/setup-openscad@setup-openscad-v1.0.0
+uses: kellerlabs/homeracker/.github/actions/setup-openscad@setup-openscad-v2.0.0
 ```

--- a/.github/actions/setup-openscad/README.md
+++ b/.github/actions/setup-openscad/README.md
@@ -17,7 +17,9 @@ steps:
   - uses: actions/checkout@v6
 
   - name: Setup OpenSCAD
-    uses: kellerlabs/homeracker/.github/actions/setup-openscad@setup-openscad-v1
+    uses: kellerlabs/homeracker/.github/actions/setup-openscad@setup-openscad-v2
+    with:
+      scadm-requirements: requirements.txt
 ```
 
 > Requires a `scadm.json` in the repo root. See [scadm docs](../../../cmd/scadm/README.md) for config format.
@@ -38,16 +40,20 @@ steps:
 
 | Input | Description | Default |
 |---|---|---|
-| `scadm-version` | Pinned scadm PyPI version. Also used in the cache key. | See [action.yml](action.yml) |
-| `scadm-source` | Local path for editable scadm install. Overrides PyPI version and re-runs `scadm install`. | _(empty)_ |
+| `scadm-version` | Pinned scadm PyPI version. Takes precedence over `scadm-requirements`. | _(empty)_ |
+| `scadm-requirements` | Path to a `requirements.txt` containing a pinned scadm version (e.g. `scadm==0.6.3`). Used when `scadm-version` is not set. | _(empty)_ |
+| `scadm-source` | Local path for editable scadm install. Overrides both `scadm-version` and `scadm-requirements`. | _(empty)_ |
+
+> **Priority:** `scadm-source` > `scadm-version` > `scadm-requirements`. At least one must be provided.
 
 ## What it does
 
 1. Sets up Python 3.x
 2. Installs system dependencies (`xvfb`, `libglu1-mesa`, `libfuse2`, `libegl1`, `libxcb-cursor0`)
-3. Caches `bin/openscad/` keyed on runner OS, scadm version, `scadm.json`, and local source hash (when `scadm-source` is set)
-4. Installs [scadm](../../../cmd/scadm/README.md) — pinned from PyPI, or from a local path if `scadm-source` is set
-5. Runs `scadm install` to download OpenSCAD and libraries
+3. Resolves scadm version from inputs (source > explicit version > requirements file)
+4. Caches `bin/openscad/` keyed on runner OS, resolved scadm version, `scadm.json`, and local source hash (when `scadm-source` is set)
+5. Installs [scadm](../../../cmd/scadm/README.md) — pinned from PyPI, or from a local path if `scadm-source` is set
+6. Runs `scadm install` to download OpenSCAD and libraries
 
 ## Versioning
 

--- a/.github/actions/setup-openscad/action.yml
+++ b/.github/actions/setup-openscad/action.yml
@@ -6,13 +6,19 @@ description: >
 
 inputs:
   scadm-version:
-    description: Pinned scadm PyPI version. Also used in the cache key.
+    description: Pinned scadm PyPI version. Takes precedence over scadm-requirements.
     required: false
-    default: '0.4.10'
+    default: ''
+  scadm-requirements:
+    description: >
+      Path to a requirements.txt containing a pinned scadm version (e.g. scadm==0.6.3).
+      Used when scadm-version is not set.
+    required: false
+    default: ''
   scadm-source:
     description: >
       Local path to install scadm from (editable install).
-      When set, overrides the PyPI version and re-runs scadm install.
+      When set, overrides both scadm-version and scadm-requirements.
     required: false
 
 runs:
@@ -28,11 +34,35 @@ runs:
       with:
         packages: xvfb libglu1-mesa libfuse2 libegl1 libxcb-cursor0
 
+    - name: Resolve scadm version
+      id: resolve-scadm
+      shell: bash
+      run: |
+        if [[ -n "${{ inputs.scadm-source }}" ]]; then
+          echo "version=source" >> "$GITHUB_OUTPUT"
+        elif [[ -n "${{ inputs.scadm-version }}" ]]; then
+          echo "version=${{ inputs.scadm-version }}" >> "$GITHUB_OUTPUT"
+        elif [[ -n "${{ inputs.scadm-requirements }}" ]]; then
+          if [[ ! -f "${{ inputs.scadm-requirements }}" ]]; then
+            echo "::error::scadm-requirements file not found: ${{ inputs.scadm-requirements }}"
+            exit 1
+          fi
+          version=$(grep -oP '^scadm==\K[0-9.]+' "${{ inputs.scadm-requirements }}" || true)
+          if [[ -z "$version" ]]; then
+            echo "::error::scadm not found in ${{ inputs.scadm-requirements }}"
+            exit 1
+          fi
+          echo "version=$version" >> "$GITHUB_OUTPUT"
+        else
+          echo "::error::One of scadm-version, scadm-requirements, or scadm-source must be provided"
+          exit 1
+        fi
+
     - name: Cache OpenSCAD and libraries
       uses: actions/cache@v5
       with:
         path: bin/openscad
-        key: openscad-${{ runner.os }}-${{ inputs.scadm-version }}-${{ hashFiles('scadm.json', inputs.scadm-source && format('{0}/**/constants.py', inputs.scadm-source) || 'scadm.json') }}
+        key: openscad-${{ runner.os }}-${{ steps.resolve-scadm.outputs.version }}-${{ hashFiles('scadm.json', inputs.scadm-source && format('{0}/**/constants.py', inputs.scadm-source) || 'scadm.json') }}
 
     - name: Install OpenSCAD and dependencies
       shell: bash
@@ -40,6 +70,6 @@ runs:
         if [[ -n "${{ inputs.scadm-source }}" ]]; then
           pip install -e "${{ inputs.scadm-source }}"
         else
-          pip install scadm==${{ inputs.scadm-version }}
+          pip install scadm==${{ steps.resolve-scadm.outputs.version }}
         fi
         scadm install

--- a/.github/actions/setup-openscad/action.yml
+++ b/.github/actions/setup-openscad/action.yml
@@ -47,9 +47,13 @@ runs:
             echo "::error::scadm-requirements file not found: ${{ inputs.scadm-requirements }}"
             exit 1
           fi
-          version=$(grep -oP '^scadm==\K[0-9.]+' "${{ inputs.scadm-requirements }}" || true)
+          version=$(sed -n 's/^[[:space:]]*scadm==\([^[:space:]#]*\).*/\1/p' "${{ inputs.scadm-requirements }}")
           if [[ -z "$version" ]]; then
             echo "::error::scadm not found in ${{ inputs.scadm-requirements }}"
+            exit 1
+          fi
+          if [[ $(echo "$version" | wc -l) -ne 1 ]]; then
+            echo "::error::Multiple scadm entries found in ${{ inputs.scadm-requirements }}"
             exit 1
           fi
           echo "version=$version" >> "$GITHUB_OUTPUT"

--- a/.github/workflows/test-setup-openscad.yml
+++ b/.github/workflows/test-setup-openscad.yml
@@ -1,0 +1,74 @@
+---
+name: Test Setup OpenSCAD Action
+
+on:
+  pull_request:
+    paths:
+      - '.github/actions/setup-openscad/**'
+      - '.github/workflows/test-setup-openscad.yml'
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - name: scadm-source
+            scadm-source: cmd/scadm
+            scadm-version: ''
+            scadm-requirements: ''
+            expect-failure: false
+          - name: scadm-version
+            scadm-source: ''
+            scadm-version: '0.6.3'
+            scadm-requirements: ''
+            expect-failure: false
+          - name: scadm-requirements
+            scadm-source: ''
+            scadm-version: ''
+            scadm-requirements: test-requirements.txt
+            expect-failure: false
+          - name: no-inputs
+            scadm-source: ''
+            scadm-version: ''
+            scadm-requirements: ''
+            expect-failure: true
+          - name: missing-requirements-file
+            scadm-source: ''
+            scadm-version: ''
+            scadm-requirements: nonexistent.txt
+            expect-failure: true
+    name: test (${{ matrix.name }})
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v6
+
+      - name: Create test requirements file
+        if: matrix.name == 'scadm-requirements'
+        run: echo "scadm==0.6.3" > test-requirements.txt
+
+      - name: Setup OpenSCAD
+        id: setup
+        uses: ./.github/actions/setup-openscad
+        continue-on-error: ${{ matrix.expect-failure }}
+        with:
+          scadm-source: ${{ matrix.scadm-source }}
+          scadm-version: ${{ matrix.scadm-version }}
+          scadm-requirements: ${{ matrix.scadm-requirements }}
+
+      - name: Assert expected failure
+        if: ${{ matrix.expect-failure }}
+        run: |
+          if [[ "${{ steps.setup.outcome }}" != "failure" ]]; then
+            echo "::error::Expected setup to fail but it succeeded"
+            exit 1
+          fi
+
+      - name: Verify installation
+        if: ${{ !matrix.expect-failure }}
+        run: |
+          scadm --version
+          test -d bin/openscad


### PR DESCRIPTION
## 📦 What

- ✨ New `scadm-requirements` input — pass a `requirements.txt` path and the action extracts the scadm version from it
- 🔄 `scadm-version` default changed from `0.4.10` to empty (no longer implicitly pins an outdated version)
- 📄 Updated README with new input table, usage examples, and priority chain

## 💡 Why

Consumer repos (e.g. homeracker-exclusive) had to hardcode `scadm-version` in every workflow file. Renovate doesn't track action input values, so these went stale and caused CI failures when the flattened output differed between scadm versions.

With `scadm-requirements`, the version is managed in `requirements.txt` — a single source of truth that Renovate already manages.

## 🔧 How

**Priority:** `scadm-source` > `scadm-version` > `scadm-requirements`. At least one must be provided.

Consumer repos:
```yaml
- uses: kellerlabs/homeracker/.github/actions/setup-openscad@setup-openscad-v2
  with:
    scadm-requirements: requirements.txt
```

homeracker (unchanged):
```yaml
- uses: ./.github/actions/setup-openscad
  with:
    scadm-source: cmd/scadm
```

⚠️ **Breaking:** removes the default `scadm-version: 0.4.10` — callers that relied on the default must now explicitly pass one of the three inputs.