### PR TITLE
ci(release-please): exclude sub-packages and workflows from root release

### DIFF
--- a/.github/config/release-please-config.json
+++ b/.github/config/release-please-config.json
@@ -17,7 +17,13 @@
   "packages": {
     ".": {
       "release-type": "simple",
-      "package-name": "homeracker"
+      "package-name": "homeracker",
+      "exclude-paths": [
+        "cmd/scadm",
+        ".github/actions/setup-openscad",
+        ".github/actions/sync-instructions",
+        ".github/workflows"
+      ]
     },
     "cmd/scadm": {
       "release-type": "python",


### PR DESCRIPTION
## 📦 What

Add `exclude-paths` to the root (`.`) package in `release-please-config.json`.

## 💡 Why

The `feat(setup-openscad)!:` commit triggered a major version bump on **both** `setup-openscad` (intended ✅) and `homeracker` (unintended ❌ → v3.0.0). This happened because the root `.` package picks up all commits, including those scoped to sub-packages and CI workflows.

## 🔧 How

Excluded paths from the root package:
- `cmd/scadm` — has its own release-please package
- `.github/actions/setup-openscad` — has its own release-please package
- `.github/actions/sync-instructions` — has its own release-please package
- `.github/workflows` — CI-only, no release needed

Commits touching only these paths will no longer bump the homeracker version.