### PR TITLE
fix: guard against empty PR list in automerge

### DIFF
--- a/.github/instructions/shell.instructions.md
+++ b/.github/instructions/shell.instructions.md
@@ -30,6 +30,7 @@ done < <(gh pr list --json number --jq '.[].number')
 
 # Good — command failure is caught before iterating
 prs="$(gh pr list --json number --jq '.[].number')"
+[[ -z "$prs" ]] && exit 0
 while read -r pr; do ...
 done <<< "$prs"
 ```

--- a/.github/workflows/automerge-release.yml
+++ b/.github/workflows/automerge-release.yml
@@ -24,6 +24,7 @@ jobs:
         run: |
           set -euo pipefail
           prs="$(gh pr list --label automerge --state open --json number --jq '.[].number')"
+          [[ -z "$prs" ]] && exit 0
           while read -r pr; do
             gh pr merge --auto --squash "$pr" || true
           done <<< "$prs"


### PR DESCRIPTION
## 📦 What

Add `[[ -z "$prs" ]] && exit 0` guard to `automerge-release.yml`. Update `shell.instructions.md` example to include the guard.

## 💡 Why

Herestrings (`<<<`) append a trailing newline even when the variable is empty, causing the `while read` loop to execute once with a blank `$pr`. The `|| true` masks the resulting `gh pr merge ""` error, but it's still a wasted API call.

## 🔧 How

No user-facing changes — automerge behavior is identical when PRs exist.