### PR TITLE
feat(sync-instructions): discover instruction files dynamically

### DIFF
--- a/.github/actions/sync-instructions/README.md
+++ b/.github/actions/sync-instructions/README.md
@@ -8,7 +8,7 @@ and overwrites local copies.
 Synced files:
 
 - `.github/copilot-instructions.md` — repo-wide Copilot instructions
-- `.github/instructions/*.instructions.md` — path-specific guidelines (markdown, openscad, python, renovate)
+- `.github/instructions/*.instructions.md` — all path-specific guidelines (discovered dynamically via GitHub API)
 - `.github/pull_request_template.md` — PR template
 
 ## 🤔 Why

--- a/.github/actions/sync-instructions/README.md
+++ b/.github/actions/sync-instructions/README.md
@@ -11,6 +11,11 @@ Synced files:
 - `.github/instructions/*.instructions.md` — all path-specific guidelines (discovered dynamically via GitHub API)
 - `.github/pull_request_template.md` — PR template
 
+### Requirements
+
+- `curl`, `jq` — both pre-installed on GitHub Actions runners
+- `GITHUB_TOKEN` (optional) — used for API authentication to avoid rate limits; automatically available in GitHub Actions via `${{ github.token }}`
+
 ## 🤔 Why
 
 HomeRacker maintains a well-proven, optimized instruction set that ensures consistent AI behavior

--- a/.github/actions/sync-instructions/sync-instructions.sh
+++ b/.github/actions/sync-instructions/sync-instructions.sh
@@ -13,7 +13,12 @@ set -euo pipefail
 REPO="kellerlabs/homeracker"
 REF="${1:-main}"
 BASE_URL="https://raw.githubusercontent.com/${REPO}/${REF}"
-API_URL="https://api.github.com/repos/${REPO}/contents/.github/instructions?ref=${REF}"
+API_BASE="https://api.github.com/repos/${REPO}/contents/.github/instructions"
+
+AUTH_ARGS=()
+if [[ -n "${GITHUB_TOKEN:-}" ]]; then
+    AUTH_ARGS=(-H "Authorization: token ${GITHUB_TOKEN}")
+fi
 
 # Explicit files outside .github/instructions/
 EXPLICIT_FILES=(
@@ -24,10 +29,20 @@ EXPLICIT_FILES=(
 echo "Syncing Copilot instructions from ${REPO}@${REF}..."
 
 # Discover all .instructions.md files dynamically
-instruction_names="$(curl -fsSL "${API_URL}" | jq -r '.[].name' | grep '\.instructions\.md$')"
+instruction_names="$(
+    curl -fsSL "${AUTH_ARGS[@]}" --get --data-urlencode "ref=${REF}" "${API_BASE}" \
+    | jq -r '
+        if type == "array" then
+            .[].name | select(endswith(".instructions.md"))
+        else
+            error("Expected array from GitHub contents API")
+        end
+    '
+)"
 
 FILES=("${EXPLICIT_FILES[@]}")
 while read -r name; do
+    [[ -z "${name}" ]] && continue
     FILES+=(".github/instructions/${name}")
 done <<< "${instruction_names}"
 

--- a/.github/actions/sync-instructions/sync-instructions.sh
+++ b/.github/actions/sync-instructions/sync-instructions.sh
@@ -13,18 +13,23 @@ set -euo pipefail
 REPO="kellerlabs/homeracker"
 REF="${1:-main}"
 BASE_URL="https://raw.githubusercontent.com/${REPO}/${REF}"
+API_URL="https://api.github.com/repos/${REPO}/contents/.github/instructions?ref=${REF}"
 
-# Files to sync (source path relative to repo root)
-FILES=(
+# Explicit files outside .github/instructions/
+EXPLICIT_FILES=(
     ".github/copilot-instructions.md"
-    ".github/instructions/markdown.instructions.md"
-    ".github/instructions/openscad.instructions.md"
-    ".github/instructions/python.instructions.md"
-    ".github/instructions/renovate.instructions.md"
     ".github/pull_request_template.md"
 )
 
 echo "Syncing Copilot instructions from ${REPO}@${REF}..."
+
+# Discover all .instructions.md files dynamically
+instruction_names="$(curl -fsSL "${API_URL}" | jq -r '.[].name' | grep '\.instructions\.md$')"
+
+FILES=("${EXPLICIT_FILES[@]}")
+while read -r name; do
+    FILES+=(".github/instructions/${name}")
+done <<< "${instruction_names}"
 
 TMPDIR=$(mktemp -d)
 trap 'rm -rf "${TMPDIR}"' EXIT
@@ -44,7 +49,7 @@ for file in "${FILES[@]}"; do
     fi
 done
 
-if [ "${FAILED}" -eq 1 ]; then
+if [[ "${FAILED}" -eq 1 ]]; then
     echo ""
     echo "ERROR: One or more files failed to download"
     exit 1


### PR DESCRIPTION
## 📦 What

Replace hardcoded instruction file list in `sync-instructions.sh` with dynamic discovery via GitHub API.

## 💡 Why

The hardcoded list missed `shell.instructions.md` when it was added. New instruction files should be synced automatically without requiring script updates.

## 🔧 How

Uses `https://api.github.com/repos/kellerlabs/homeracker/contents/.github/instructions` to list all `*.instructions.md` files at runtime. Requires `jq` (available on all GitHub Actions runners). Explicit files outside the instructions directory (`.github/copilot-instructions.md`, `.github/pull_request_template.md`) remain hardcoded.