### PR TITLE
feat: improve makerworld description tooling

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -36,6 +36,7 @@ HomeRacker is a modular 3D-printable rack-building system. Core components use p
   - Types: `feat`, `fix`, `docs`, `chore`, `refactor`, `test`
   - Format: `type(scope): description` or `type: description`
   - Breaking changes: Add `!` (e.g., `feat!: change base unit`)
+  - **NEVER amend commits** (`--amend`). PRs are squash-merged, so extra commits are fine.
 
 ## Terminal Session Setup
 Before terminal operations, consider running these steps (use best judgement):

--- a/.github/skills/makerworld-description/SKILL.md
+++ b/.github/skills/makerworld-description/SKILL.md
@@ -44,7 +44,7 @@ Given a MakerWorld model URL, extract the description into a `DESCRIPTION.md` fi
    - Preserve: headings (##, ###), bold/italic, bullet lists, numbered lists, links, images, linked images (`[![alt](img)](url)`), horizontal rules
    - Strip: `[Image: Image]` placeholders, duplicate blank lines, trailing whitespace
    - Keep image URLs as-is initially (they'll be downloaded next)
-   - **Use `<img>` tags instead of markdown image syntax** for all images. This allows preserving the `width` attribute. After downloading an image (step 5), read its actual pixel width and set `width` on the tag (do NOT set `height` — omitting it lets the browser scale proportionally). The user can then adjust the width to match the MakerWorld layout. Example:
+   - **Use `<img>` tags instead of markdown image syntax** for all images. This allows preserving the `width` attribute. Use `width="800"` for images whose native width is ≥ 800px; for smaller images use their native width. Exceptions: HomeRacker logo (`width="300"`), Ko-fi QR code (`width="328"`). Do NOT set `height` — omitting it lets the browser scale proportionally. Example:
      ```html
      <img src="https://raw.githubusercontent.com/.../logo.webp" alt="Logo" width="800">
      ```
@@ -71,7 +71,7 @@ Given a MakerWorld model URL, extract the description into a `DESCRIPTION.md` fi
    - After downloading, get pixel dimensions with `python cmd/export/image_dimensions.py <images-dir>` (for reference only — do not use native dimensions for `width`)
    - **Standard image width**: Use `width="800"` for all description images whose native width is ≥ 800px. For smaller images, use their native width. Exceptions: HomeRacker logo (`width="300"`), Ko-fi QR code (`width="328"`). This ensures a uniform look across all model descriptions.
    - **Check for common images**: Some images are shared across all models (e.g. `collection_banner.webp`, `kofi_qr_code.webp`). These live in `assets/common/makerworld/images/`. If a downloaded image already exists there (same content), delete the per-model copy and reference the common one: `https://raw.githubusercontent.com/kellerlabs/assets/main/common/makerworld/images/filename.webp`
-   - Reference model-specific images using absolute URLs in `<img>` tags: `<img src="https://raw.githubusercontent.com/kellerlabs/assets/main/<target-repo>/models/<name>/makerworld/images/filename.png" alt="Description" width="W">`
+   - Reference model-specific images using absolute URLs in `<img>` tags, applying the standard width rule above: use `width="800"` when the native width is ≥ 800px; otherwise use the native width. Example: `<img src="https://raw.githubusercontent.com/kellerlabs/assets/main/<target-repo>/models/<name>/makerworld/images/filename.png" alt="Description" width="800">`
 
 5a. **Resolve orphan linked images** (from step 4):
    - For each `[](url)` pattern found, present the user with a numbered list showing the link target URL

--- a/.github/skills/makerworld-description/SKILL.md
+++ b/.github/skills/makerworld-description/SKILL.md
@@ -68,8 +68,10 @@ Given a MakerWorld model URL, extract the description into a `DESCRIPTION.md` fi
    - Skip external reference images (e.g. `encrypted-tbn0.gstatic.com` meme images) — keep those as URLs
    - Download MakerWorld CDN images to the **assets repo**: `assets/<target-repo>/models/<name>/makerworld/images/`
    - Use descriptive filenames based on context (e.g. `diagonal_supports.png`, `showcase_rack.jpg`)
-   - After downloading, read the actual pixel width of each image and use `<img>` tags with `width` set to the image's native width (omit `height` for proper scaling)
-   - Reference images using absolute URLs in `<img>` tags: `<img src="https://raw.githubusercontent.com/kellerlabs/assets/main/<target-repo>/models/<name>/makerworld/images/filename.png" alt="Description" width="W">`
+   - After downloading, get pixel dimensions with `python cmd/export/image_dimensions.py <images-dir>` (for reference only — do not use native dimensions for `width`)
+   - **Standard image width**: Use `width="800"` for all description images whose native width is ≥ 800px. For smaller images, use their native width. Exceptions: HomeRacker logo (`width="300"`), Ko-fi QR code (`width="328"`). This ensures a uniform look across all model descriptions.
+   - **Check for common images**: Some images are shared across all models (e.g. `collection_banner.webp`, `kofi_qr_code.webp`). These live in `assets/common/makerworld/images/`. If a downloaded image already exists there (same content), delete the per-model copy and reference the common one: `https://raw.githubusercontent.com/kellerlabs/assets/main/common/makerworld/images/filename.webp`
+   - Reference model-specific images using absolute URLs in `<img>` tags: `<img src="https://raw.githubusercontent.com/kellerlabs/assets/main/<target-repo>/models/<name>/makerworld/images/filename.png" alt="Description" width="W">`
 
 5a. **Resolve orphan linked images** (from step 4):
    - For each `[](url)` pattern found, present the user with a numbered list showing the link target URL
@@ -137,6 +139,33 @@ assets/<repo>/models/<name>/makerworld/images/
 └── diagonal_supports.png
 ```
 
+Common images shared across all models are stored in the assets repo:
+```
+assets/common/makerworld/images/
+├── homeracker_logo_banner.webp    # HomeRacker logo (linked to homeracker.org)
+├── collection_banner.webp         # Official HomeRacker Collection banner
+└── kofi_qr_code.webp              # Ko-fi donation QR code
+```
+
+Reference via: `https://raw.githubusercontent.com/kellerlabs/assets/main/common/makerworld/images/<file>`
+
+## 🔁 Common Description Elements
+
+All HomeRacker MakerWorld descriptions share recurring elements. When extracting, verify these are present:
+
+1. **Centered header block** — everything from the top of the description until the first video embed or model-specific content must be centered using HTML style blocks. The logo is always `width="300"` and linked to `homeracker.org`. Pattern:
+   ```html
+   <p style="text-align: center">Intro text</p>
+   <h2 style="text-align: center">Model Title</h2>
+   <p style="text-align: center"><a href="https://homeracker.org/"><img src=".../common/makerworld/images/homeracker_logo_banner.webp" alt="HomeRacker Logo" width="300"></a></p>
+   <p style="text-align: center">Subtitle / links</p>
+   ```
+2. **Collection banner** — linked image to the Official HomeRacker Collection. Uses `common/makerworld/images/collection_banner.webp`
+3. **Ko-fi QR code** — in the ☕ Support section. Uses `common/makerworld/images/kofi_qr_code.webp`
+4. **"🏡 What is HomeRacker?" section** (non-core models only) — includes the HomeRacker Core video embed (`g8k6X_axYug`) immediately after the heading, followed by links to homeracker.org and the collection
+
+These elements are often dropped by `fetch_webpage` (logo as orphan linked image, video as invisible iframe). Always check for them during extraction.
+
 ## ⚠️ Important Notes
 
 - **Cross-repo skill**: Requires both the source repo (`homeracker` or `homeracker-exclusive`) and the [`kellerlabs/assets`](https://github.com/kellerlabs/assets) repo. Maintainers push images directly to `assets/main`. Outside collaborators must open a PR on the assets repo for image changes.
@@ -145,7 +174,7 @@ assets/<repo>/models/<name>/makerworld/images/
 - The conversion script embeds local images as base64 data URIs so the HTML is fully self-contained — no broken links, no browser permissions needed. External image URLs (http/https) are passed through unchanged.
 - Since images are now hosted in the `kellerlabs/assets` repo with absolute URLs, `md-to-mw.py` passes them through directly — no base64 encoding needed for assets-hosted images.
 - **Alignment**: Use inline HTML blocks (`<h2 style="text-align: center">`, `<p style="text-align: center">`) to preserve centered headings, images, and text from MakerWorld. These render correctly on GitHub and pass through to `md-to-mw.py` HTML output.
-- **Image sizing**: `fetch_webpage` strips HTML attributes, so image dimensions are not available from the source page. Use `<img>` tags with `width` set to the actual downloaded image width (omit `height` so images scale proportionally). The user can then adjust the width to match the MakerWorld layout.
+- **Image sizing**: Use `width="800"` as the standard for all description images whose native width is ≥ 800px; for smaller images use their native width (omit `height` so images scale proportionally). Exceptions: HomeRacker logo (`width="300"`), Ko-fi QR code (`width="328"`).
 - MakerWorld CDN images (from `makerworld.bblmw.com`) should be downloaded to the assets repo during extraction. External reference images (memes, badges, etc.) can stay as external URLs.
 
 ## 🐛 Known Limitations

--- a/cmd/export/README.md
+++ b/cmd/export/README.md
@@ -125,6 +125,20 @@ To add a new model type (e.g., `models/newtype/`):
    ```
 3. Commit — the pre-commit hook will automatically flatten to `models/newtype/flattened/`
 
+## 📐 Image Dimensions
+
+Prints pixel dimensions of image files (WebP, PNG, JPEG) by reading file headers directly — no external dependencies.
+
+```bash
+# Directory of images
+python cmd/export/image_dimensions.py path/to/images/
+
+# Single file
+python cmd/export/image_dimensions.py path/to/image.webp
+```
+
+Output: `filename.webp: 4032x2268`
+
 ## PNG Export
 
 Exports an isometric preview PNG from any OpenSCAD model.

--- a/cmd/export/image_dimensions.py
+++ b/cmd/export/image_dimensions.py
@@ -4,8 +4,8 @@
 Reads image headers directly — no external dependencies required.
 
 Usage:
-    python cmd/export/image-dimensions.py path/to/images/
-    python cmd/export/image-dimensions.py path/to/single-image.webp
+    python cmd/export/image_dimensions.py path/to/images/
+    python cmd/export/image_dimensions.py path/to/single-image.webp
 """
 
 import struct
@@ -107,16 +107,31 @@ def get_dimensions(path: Path) -> tuple[int, int] | None:
 
 
 def main():
+    """Print dimensions for supported image files passed on the command line.
+
+    Raises:
+        SystemExit: If no input paths are provided.
+    """
     if len(sys.argv) < 2:
         print(f"Usage: {sys.argv[0]} <path> [path ...]", file=sys.stderr)
         sys.exit(1)
 
     for arg in sys.argv[1:]:
         target = Path(arg)
-        files = sorted(target.iterdir()) if target.is_dir() else [target]
+        if not target.exists():
+            print(f"{arg}: <not found>", file=sys.stderr)
+            continue
+        try:
+            files = sorted(target.iterdir()) if target.is_dir() else [target]
+        except OSError as exc:
+            print(f"{arg}: {exc}", file=sys.stderr)
+            continue
         for f in files:
             if f.suffix.lower() in READERS:
-                dims = get_dimensions(f)
+                try:
+                    dims = get_dimensions(f)
+                except OSError:
+                    dims = None
                 if dims:
                     print(f"{f.name}: {dims[0]}x{dims[1]}")
                 else:

--- a/cmd/export/image_dimensions.py
+++ b/cmd/export/image_dimensions.py
@@ -1,0 +1,127 @@
+#!/usr/bin/env python3
+"""Print pixel dimensions of image files (WebP, PNG, JPEG).
+
+Reads image headers directly — no external dependencies required.
+
+Usage:
+    python cmd/export/image-dimensions.py path/to/images/
+    python cmd/export/image-dimensions.py path/to/single-image.webp
+"""
+
+import struct
+import sys
+from pathlib import Path
+
+
+def webp_dimensions(path: Path) -> tuple[int, int] | None:
+    """Read width and height from a WebP file header.
+
+    Args:
+        path: Path to a WebP image file.
+
+    Returns:
+        Tuple of (width, height) or None if unreadable.
+    """
+    with path.open("rb") as f:
+        header = f.read(30)
+    if len(header) < 30 or header[:4] != b"RIFF" or header[8:12] != b"WEBP":
+        return None
+    chunk = header[12:16]
+    if chunk == b"VP8 ":
+        w = (header[26] | (header[27] << 8)) & 0x3FFF
+        h = (header[28] | (header[29] << 8)) & 0x3FFF
+        return w, h
+    if chunk == b"VP8L":
+        bits = int.from_bytes(header[21:25], "little")
+        return (bits & 0x3FFF) + 1, ((bits >> 14) & 0x3FFF) + 1
+    if chunk == b"VP8X":
+        w = int.from_bytes(header[24:27], "little") + 1
+        h = int.from_bytes(header[27:30], "little") + 1
+        return w, h
+    return None
+
+
+def png_dimensions(path: Path) -> tuple[int, int] | None:
+    """Read width and height from a PNG file header.
+
+    Args:
+        path: Path to a PNG image file.
+
+    Returns:
+        Tuple of (width, height) or None if unreadable.
+    """
+    with path.open("rb") as f:
+        header = f.read(24)
+    if len(header) < 24 or header[:8] != b"\x89PNG\r\n\x1a\n":
+        return None
+    w, h = struct.unpack(">II", header[16:24])
+    return w, h
+
+
+def jpeg_dimensions(path: Path) -> tuple[int, int] | None:
+    """Read width and height from a JPEG file header.
+
+    Args:
+        path: Path to a JPEG image file.
+
+    Returns:
+        Tuple of (width, height) or None if unreadable.
+    """
+    with path.open("rb") as f:
+        if f.read(2) != b"\xff\xd8":
+            return None
+        while True:
+            marker = f.read(2)
+            if len(marker) < 2:
+                return None
+            if marker[0] != 0xFF:
+                return None
+            if marker[1] in (0xC0, 0xC1, 0xC2):
+                f.read(3)  # length + precision
+                h, w = struct.unpack(">HH", f.read(4))
+                return w, h
+            length = struct.unpack(">H", f.read(2))[0]
+            f.read(length - 2)
+    return None
+
+
+READERS = {
+    ".webp": webp_dimensions,
+    ".png": png_dimensions,
+    ".jpg": jpeg_dimensions,
+    ".jpeg": jpeg_dimensions,
+}
+
+
+def get_dimensions(path: Path) -> tuple[int, int] | None:
+    """Get pixel dimensions for a supported image file.
+
+    Args:
+        path: Path to an image file (.webp, .png, .jpg, .jpeg).
+
+    Returns:
+        Tuple of (width, height) or None if format unsupported/unreadable.
+    """
+    reader = READERS.get(path.suffix.lower())
+    return reader(path) if reader else None
+
+
+def main():
+    if len(sys.argv) < 2:
+        print(f"Usage: {sys.argv[0]} <path> [path ...]", file=sys.stderr)
+        sys.exit(1)
+
+    for arg in sys.argv[1:]:
+        target = Path(arg)
+        files = sorted(target.iterdir()) if target.is_dir() else [target]
+        for f in files:
+            if f.suffix.lower() in READERS:
+                dims = get_dimensions(f)
+                if dims:
+                    print(f"{f.name}: {dims[0]}x{dims[1]}")
+                else:
+                    print(f"{f.name}: <unreadable>", file=sys.stderr)
+
+
+if __name__ == "__main__":
+    main()

--- a/cmd/export/md-to-mw.py
+++ b/cmd/export/md-to-mw.py
@@ -148,7 +148,10 @@ def github_source_url(file_path: Path) -> str | None:
     if not match:
         return None
     owner_repo = match.group(1)
-    rel_path = file_path.relative_to(repo_root).as_posix()
+    try:
+        rel_path = file_path.relative_to(repo_root).as_posix()
+    except ValueError:
+        return None
     return f"https://github.com/{owner_repo}/blob/main/{rel_path}"
 
 

--- a/cmd/export/md-to-mw.py
+++ b/cmd/export/md-to-mw.py
@@ -15,6 +15,7 @@ import argparse
 import base64
 import mimetypes
 import re
+import subprocess
 import sys
 import webbrowser
 from pathlib import Path
@@ -125,6 +126,32 @@ def add_block_spacing(html: str) -> str:
     )
 
 
+def github_source_url(file_path: Path) -> str | None:
+    """Derive a GitHub blob URL for a file from git remote and repo root.
+
+    Args:
+        file_path: Absolute path to a file inside a git repository.
+
+    Returns:
+        GitHub URL string, or None if git info unavailable.
+    """
+    try:
+        repo_root = Path(
+            subprocess.check_output(["git", "rev-parse", "--show-toplevel"], cwd=file_path.parent, text=True).strip()
+        )
+        remote = subprocess.check_output(["git", "remote", "get-url", "origin"], cwd=repo_root, text=True).strip()
+    except (subprocess.CalledProcessError, FileNotFoundError):
+        return None
+
+    # Normalise git@github.com:owner/repo.git and https://github.com/owner/repo.git
+    match = re.search(r"github\.com[:/](.+?)(?:\.git)?$", remote)
+    if not match:
+        return None
+    owner_repo = match.group(1)
+    rel_path = file_path.relative_to(repo_root).as_posix()
+    return f"https://github.com/{owner_repo}/blob/main/{rel_path}"
+
+
 def convert(input_path: Path) -> str:
     """Convert a DESCRIPTION.md file to HTML with embedded local images.
 
@@ -142,10 +169,12 @@ def convert(input_path: Path) -> str:
     html = convert_youtube_embeds(html)
     html = add_block_spacing(html)
 
+    source_url = github_source_url(input_path)
+    from_md = f'from <a href="{source_url}">Markdown</a>' if source_url else "from Markdown"
     footer = (
-        "\n&nbsp;\n<p><em>This description was generated from Markdown using "
+        f"\n&nbsp;\n<p><em>This description was generated {from_md} using "
         '<a href="https://github.com/kellerlabs/homeracker/blob/main/docs/makerworld-workflow.md">'
-        "md-to-mw</a> — version-controlled descriptions for easier maintenance.</em></p>"
+        "md-to-mw</a> \u2014 version-controlled descriptions for easier maintenance.</em></p>"
     )
     html += footer
 

--- a/models/core/makerworld/DESCRIPTION.md
+++ b/models/core/makerworld/DESCRIPTION.md
@@ -5,7 +5,7 @@ extracted: 2026-04-13
 
 <h2 style="text-align: center">HomeRacker - Core</h2>
 
-<p style="text-align: center"><a href="https://homeracker.org/"><img src="https://raw.githubusercontent.com/kellerlabs/assets/main/homeracker/models/core/makerworld/images/homeracker_logo_banner.webp" alt="HomeRacker Logo" width="300"></a></p>
+<p style="text-align: center"><a href="https://homeracker.org/"><img src="https://raw.githubusercontent.com/kellerlabs/assets/main/common/makerworld/images/homeracker_logo_banner.webp" alt="HomeRacker Logo" width="300"></a></p>
 
 <p style="text-align: center"><a href="https://homeracker.org/">https://homeracker.org/</a></p>
 
@@ -99,7 +99,7 @@ For the full and always up-to-date project catalog, please see the
 
 ### [The Official HomeRacker Collection](https://makerworld.com/collections/5970240)
 
-<a href="https://makerworld.com/en/collections/5970240-homeracker-official-catalog"><img src="https://raw.githubusercontent.com/kellerlabs/assets/main/homeracker/models/core/makerworld/images/collection_banner.webp" alt="Official HomeRacker Collection" width="800"></a>
+<a href="https://makerworld.com/en/collections/5970240-homeracker-official-catalog"><img src="https://raw.githubusercontent.com/kellerlabs/assets/main/common/makerworld/images/collection_banner.webp" alt="Official HomeRacker Collection" width="800"></a>
 
 Here's some highlight projects I created using HomeRacker-Core as the base:
 
@@ -154,7 +154,7 @@ If you appreciate this model and wanna buy me coffee, you can do so here: [https
 
 Or simply scan this QR-Code:
 
-<p style="text-align: center"><img src="https://raw.githubusercontent.com/kellerlabs/assets/main/homeracker/models/core/makerworld/images/kofi_qr_code.webp" alt="Ko-fi QR Code" width="328"></p>
+<p style="text-align: center"><img src="https://raw.githubusercontent.com/kellerlabs/assets/main/common/makerworld/images/kofi_qr_code.webp" alt="Ko-fi QR Code" width="328"></p>
 
 ## 📜 Changelog
 [2026-03-15]


### PR DESCRIPTION
## 📦 What

- ✨ `image_dimensions.py` — zero-dependency script to read image widths from WebP/PNG/JPEG headers
- 🔗 `md-to-mw.py` footer now links "Markdown" to the source DESCRIPTION.md on GitHub (derived from `git remote`)
- 🔄 Moved shared images (logo, collection banner, Ko-fi QR) → `assets/common/makerworld/images/`
- 📝 Updated core `DESCRIPTION.md` to reference `common/` paths
- 📖 Skill updated: common elements checklist, centered header pattern, `width="800"` standard

## 💡 Why

- 🧠 `image_dimensions.py` avoids ad-hoc scripts each session — reusable across extractions
- 🔗 Source link in footer connects MakerWorld readers to the version-controlled description
- 📁 Shared images in `common/` avoid duplication across model descriptions in the assets repo
- 📏 Standard `width="800"` ensures uniform layout across all MakerWorld descriptions

## 🔧 How

```bash
# Get image dimensions
python cmd/export/image_dimensions.py path/to/images/

# Generate HTML (now with source link in footer)
python cmd/export/md-to-mw.py models/core/makerworld/DESCRIPTION.md
```

Common images: `https://raw.githubusercontent.com/kellerlabs/assets/main/common/makerworld/images/<file>`
