### PR TITLE
refactor(renovate): centralize custom managers in shared preset

### DIFF
--- a/.github/instructions/renovate.instructions.md
+++ b/.github/instructions/renovate.instructions.md
@@ -14,8 +14,8 @@ applyTo: "renovate.json5,renovate-dependencies.json"
 ## Configuration
 
 - Main config: `renovate.json5` in project root.
-- Shared dependency preset: `renovate-dependencies.json` (consumed by downstream repos).
-- Custom datasources and managers: defined in `renovate.json5` when upstream packages lack standard tracking.
+- Shared dependency preset: `renovate-dependencies.json` — reusable custom managers and datasources for `scadm.json` tracking, consumed by downstream repos via `extends`. No `packageRules` — consumers decide grouping, schedules, and automerge.
+- Repo-specific config: `renovate.json5` — package rules, schedules, automerge, and any repo-only overrides.
 
 ## Testing
 

--- a/renovate-dependencies.json
+++ b/renovate-dependencies.json
@@ -6,7 +6,7 @@
       "fileFormat": "json",
       "managerFilePatterns": ["/^scadm\\.json$/"],
       "matchStrings": [
-        "dependencies[$contains(version, /^[a-f0-9]{40}$/)].{\"depName\": repository, \"currentDigest\": version, \"currentValue\": \"master\", \"packageName\": \"https://github.com/\" & repository & \".git\"}"
+        "dependencies[$match(version, /^[a-f0-9]{40}$/)].{\"depName\": repository, \"currentDigest\": version, \"currentValue\": \"master\", \"packageName\": \"https://github.com/\" & repository & \".git\"}"
       ],
       "datasourceTemplate": "git-refs",
       "versioningTemplate": "git"
@@ -26,7 +26,7 @@
       "fileFormat": "json",
       "managerFilePatterns": ["/^scadm\\.json$/"],
       "matchStrings": [
-        "dependencies[repository != 'kellerlabs/homeracker' and $not($contains(version, /^[a-f0-9]{40}$/))].{\"depName\": repository, \"currentValue\": version}"
+        "dependencies[repository != 'kellerlabs/homeracker' and $not($match(version, /^[a-f0-9]{40}$/))].{\"depName\": repository, \"currentValue\": version}"
       ],
       "datasourceTemplate": "github-releases",
       "versioningTemplate": "semver"

--- a/renovate-dependencies.json
+++ b/renovate-dependencies.json
@@ -2,35 +2,51 @@
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "customManagers": [
     {
-      "customType": "regex",
-      "fileMatch": ["^scadm\\.json$"],
+      "customType": "jsonata",
+      "fileFormat": "json",
+      "managerFilePatterns": ["/^scadm\\.json$/"],
       "matchStrings": [
-        "\"repository\":\\s*\"(?<depName>[^\"]+)\",\\s*\"version\":\\s*\"(?<currentDigest>[a-f0-9]{40})\""
+        "dependencies[$contains(version, /^[a-f0-9]{40}$/)].{\"depName\": repository, \"currentDigest\": version, \"currentValue\": \"master\", \"packageName\": \"https://github.com/\" & repository & \".git\"}"
       ],
-      "currentValueTemplate": "master",
-      "depNameTemplate": "{{depName}}",
-      "packageNameTemplate": "https://github.com/{{depName}}.git",
       "datasourceTemplate": "git-refs",
       "versioningTemplate": "git"
     },
     {
-      "customType": "regex",
-      "fileMatch": ["^scadm\\.json$"],
+      "customType": "jsonata",
+      "fileFormat": "json",
+      "managerFilePatterns": ["/^scadm\\.json$/"],
       "matchStrings": [
-        "\"repository\":\\s*\"kellerlabs/homeracker\"[,\\s]+\"version\":\\s*\"(?<currentValue>homeracker-v\\d+\\.\\d+\\.\\d+)\""
+        "dependencies[repository = 'kellerlabs/homeracker'].{\"depName\": repository, \"currentValue\": version}"
       ],
       "datasourceTemplate": "github-tags",
-      "depNameTemplate": "kellerlabs/homeracker",
       "versioningTemplate": "regex:^homeracker-v(?<major>\\d+)\\.(?<minor>\\d+)\\.(?<patch>\\d+)$"
     },
     {
-      "customType": "regex",
-      "fileMatch": ["^scadm\\.json$"],
+      "customType": "jsonata",
+      "fileFormat": "json",
+      "managerFilePatterns": ["/^scadm\\.json$/"],
       "matchStrings": [
-        "\"repository\":\\s*\"(?<depName>[^\"]+)\",\\s*\"version\":\\s*\"(?<currentValue>v?\\d+\\.\\d+\\.\\d+)\""
+        "dependencies[repository != 'kellerlabs/homeracker' and $not($contains(version, /^[a-f0-9]{40}$/))].{\"depName\": repository, \"currentValue\": version}"
       ],
       "datasourceTemplate": "github-releases",
       "versioningTemplate": "semver"
+    },
+    {
+      "customType": "jsonata",
+      "fileFormat": "json",
+      "managerFilePatterns": ["/^scadm\\.json$/"],
+      "matchStrings": [
+        "openscad[version != 'latest'].{\"depName\": \"OpenSCAD\", \"currentValue\": version}"
+      ],
+      "datasourceTemplate": "custom.openscad-snapshots",
+      "extractVersionTemplate": "^OpenSCAD-(?<version>\\d{4}\\.\\d{2}\\.\\d{2})-x86_64\\.AppImage$",
+      "versioningTemplate": "loose"
     }
-  ]
+  ],
+  "customDatasources": {
+    "openscad-snapshots": {
+      "defaultRegistryUrlTemplate": "https://files.openscad.org/snapshots/",
+      "format": "html"
+    }
+  }
 }

--- a/renovate.json5
+++ b/renovate.json5
@@ -16,29 +16,7 @@
   "semanticCommits": "enabled",
   "semanticCommitType": "deps",
   "semanticCommitScope": null,
-  // Custom managers for tracking OpenSCAD and BOSL2 versions
-  "customManagers": [
-    {
-      "customType": "jsonata",
-      "fileFormat": "json",
-      // Track pinned OpenSCAD nightly version in scadm.json (skipped when "latest")
-      "managerFilePatterns": ["/^scadm\\.json$/"],
-      "matchStrings": [
-        "openscad[version != 'latest'].{\"depName\": \"OpenSCAD\", \"currentValue\": version}"
-      ],
-      "datasourceTemplate": "custom.openscad-snapshots",
-      "extractVersionTemplate": "^OpenSCAD-(?<version>\\d{4}\\.\\d{2}\\.\\d{2})-x86_64\\.AppImage$",
-      "versioningTemplate": "loose"
-    }
-  ],
-  // Custom datasource for OpenSCAD nightly snapshots
-  "customDatasources": {
-    "openscad-snapshots": {
-      "defaultRegistryUrlTemplate": "https://files.openscad.org/snapshots/",
-      "format": "html"
-    }
-  },
-  // Package rules to group OpenSCAD updates and override semanticPrefixFixDepsChoreOthers preset
+  // Package rules to group updates and override semanticPrefixFixDepsChoreOthers preset
   "packageRules": [
     // Override the semanticPrefixFixDepsChoreOthers preset from config:recommended
     // That preset sets semanticCommitType to "chore" for everything by default


### PR DESCRIPTION
## 📦 What

Migrate all `scadm.json` custom managers from **regex → JSONata** and consolidate OpenSCAD nightly tracking (manager + datasource) into `renovate-dependencies.json`.

- 3 regex managers → 4 JSONata managers (git-refs, github-tags, github-releases, openscad-snapshots)
- `customDatasources.openscad-snapshots` moved to shared preset
- `customManagers` and `customDatasources` removed from `renovate.json5`
- OpenSCAD nightly `packageRule` stays in `renovate.json5` (consumer decides)
- 📝 Updated `renovate.instructions.md` to clarify preset vs. consumer responsibilities

## 💡 Why

The shared preset (`renovate-dependencies.json`) is consumed by both `homeracker` and `homeracker-exclusive`. Moving managers + datasources there means:
- 🔁 DRY — one place to maintain `scadm.json` tracking logic
- 🧩 JSONata natively parses JSON structure (no multiline regex fragility)
- ⚖️ Clean separation: preset provides *what* to track, consumers decide *how* (rules, schedules, automerge)

## 🔧 How

No workflow changes. After merge, downstream repos automatically pick up the new JSONata managers via their `extends` reference.

Verified via `test-renovate-local.sh` dry-run — all deps extracted:
- ✅ `BelfrySCAD/BOSL2` @ `v2.0.731` (github-releases)
- ✅ `OpenSCAD` @ `2026.04.16` (custom.openscad-snapshots)
