### PR TITLE
fix(renovate): revert $match to $contains in JSONata queries

### DIFF
--- a/renovate-dependencies.json
+++ b/renovate-dependencies.json
@@ -6,7 +6,7 @@
       "fileFormat": "json",
       "managerFilePatterns": ["/^scadm\\.json$/"],
       "matchStrings": [
-        "dependencies[$match(version, /^[a-f0-9]{40}$/)].{\"depName\": repository, \"currentDigest\": version, \"currentValue\": \"master\", \"packageName\": \"https://github.com/\" & repository & \".git\"}"
+        "dependencies[$contains(version, /^[a-f0-9]{40}$/)].{\"depName\": repository, \"currentDigest\": version, \"currentValue\": \"master\", \"packageName\": \"https://github.com/\" & repository & \".git\"}"
       ],
       "datasourceTemplate": "git-refs",
       "versioningTemplate": "git"
@@ -26,7 +26,7 @@
       "fileFormat": "json",
       "managerFilePatterns": ["/^scadm\\.json$/"],
       "matchStrings": [
-        "dependencies[repository != 'kellerlabs/homeracker' and $not($match(version, /^[a-f0-9]{40}$/))].{\"depName\": repository, \"currentValue\": version}"
+        "dependencies[repository != 'kellerlabs/homeracker' and $not($contains(version, /^[a-f0-9]{40}$/))].{\"depName\": repository, \"currentValue\": version}"
       ],
       "datasourceTemplate": "github-releases",
       "versioningTemplate": "semver"

--- a/scadm.json
+++ b/scadm.json
@@ -1,7 +1,7 @@
 {
   "openscad": {
     "type": "nightly",
-    "version": "2026.04.16"
+    "version": "2026.04.01"
   },
   "dependencies": [
     {


### PR DESCRIPTION
## 📦 What

Reverts `$match` → `$contains` in JSONata custom manager queries in `renovate-dependencies.json`. Pins OpenSCAD to `2026.04.01` for Renovate update detection testing.

## 💡 Why

PR #344 accepted a Copilot reviewer suggestion to change `$contains` to `$match` for regex predicates. ❌ This broke all three JSONata dependency managers (git-refs, github-tags, github-releases) — including BOSL2 detection.

**Root cause**: `$match(str, regex)` returns a **match object** (or `undefined`), not a boolean. Renovate's JSONata filter evaluation requires boolean predicates. `$contains(str, regex)` returns a **boolean** and is the correct function.

OpenSCAD was also left at `2026.04.16` (latest), preventing Renovate from detecting available updates.

## 🔧 How

- `$match` → `$contains` in two JSONata queries (git-refs SHA filter + github-releases exclusion)
- OpenSCAD version `2026.04.16` → `2026.04.01` so Renovate can propose the update

✅ Verified via local Renovate dry-run:
- `BelfrySCAD/BOSL2` @ `v2.0.731` extracted correctly
- `OpenSCAD` @ `2026.04.01` with update to `2026.04.16` detected
