### PR TITLE
fix(panel): stabilize anchor positions and correct mount_extension

### DIFF
--- a/models/panel/README.md
+++ b/models/panel/README.md
@@ -147,7 +147,7 @@ The `panel()` module is fully BOSL2-attachable. Its bounding box encompasses all
 
 ### Inter-Fit Panels
 
-Anchors align directly with the panel's base plate + mount surfaces. The bounding box extends `BASE_STRENGTH + TOLERANCE/2` beyond the base plate on each side that has a support mount plate enabled.
+Anchors align directly with the panel's base plate + mount surfaces. The bounding box extends `BASE_STRENGTH` beyond the base plate on each side that has support mount plates (i.e. when units > 2 on that axis). The extension is always symmetric — disabling individual mount surfaces does not shrink or shift the bounding box.
 
 ### Full Cover Panels
 
@@ -160,9 +160,9 @@ On Full Cover panels, the overlap base plate is larger than the mount surface bo
 
 > 💡 **Example**: A keystone jack attached with `align(BACK,BOTTOM,inside=true)` perfectly aligns with the support plate edge, making optimal use of the panel's vertical space without intersecting the scaffold structure.
 
-### Asymmetric Mounts
+### Stable Anchors
 
-When mount surfaces are enabled on only some sides (e.g., `mount_west=true, mount_east=false`), the bounding box center shifts to stay centered on the actual geometry. Anchors account for this offset automatically.
+Anchors remain fixed regardless of which mount surfaces are enabled or disabled. Disabling a mount plate (e.g. `mount_west=false`) removes the plate geometry but does **not** shift the bounding box or anchor positions. This ensures children attached via `align()` stay in a predictable position — aligned with the support bar boundary — even when mount plates are selectively disabled.
 
 ## 📚 References
 

--- a/models/panel/lib/panel.scad
+++ b/models/panel/lib/panel.scad
@@ -214,16 +214,11 @@ module panel(units_x, units_y, panel_type = HR_PANEL_TYPE_INTERFIT, panel_cleara
 
   attachable_dimensions = [attachable_width, attachable_depth, attachable_height];
 
-
-  // Override BOTTOM anchors for Full Cover to account for base plate XY dimensions
   fullcover_addition = BASE_UNIT - panel_clearance;
   full_cover_width = units_x * BASE_UNIT + fullcover_addition;
   full_cover_depth = units_y * BASE_UNIT + fullcover_addition;
-  override = panel_type != HR_PANEL_TYPE_FULLCOVER ? undef : function (anchor)
-      anchor.z != -1 ? undef
-      : [[anchor.x * attachable_width/2, anchor.y * attachable_depth/2, -attachable_height/2]];
 
-  attachable(anchor, spin, orient, size=attachable_dimensions, override=override) {
+  attachable(anchor, spin, orient, size=attachable_dimensions) {
     down(attachable_height/2-BASE_STRENGTH/2)
     color_this(debug_colors ? HR_BLUE : HR_PANEL_PRIMARY_COLOR)
     cuboid([panel_width, panel_depth, BASE_STRENGTH],chamfer=chamfer_enabled ? BASE_CHAMFER : 0, except=TOP){

--- a/models/panel/lib/panel.scad
+++ b/models/panel/lib/panel.scad
@@ -208,18 +208,12 @@ module panel(units_x, units_y, panel_type = HR_PANEL_TYPE_INTERFIT, panel_cleara
   panel_depth = units_y * BASE_UNIT - interfit_deduction;
   attachable_height = BASE_STRENGTH + get_panel_mount_height(panel_type);
 
-  // Support mount plates extend BASE_STRENGTH + TOLERANCE/2 beyond the base plate
-  // (bottom_plate_width = BASE_STRENGTH*2 + TOLERANCE/2, overlap = BASE_STRENGTH)
-  mount_extension = BASE_STRENGTH + TOLERANCE/2;
 
-  attachable_width = panel_width + (units_y > 2 ? (mount_west ? mount_extension : 0) + (mount_east ? mount_extension : 0) : 0);
-  attachable_depth = panel_depth + (units_x > 2 ? (mount_north ? mount_extension : 0) + (mount_south ? mount_extension : 0) : 0);
+  attachable_width = panel_width + (units_y > 2 ? BASE_STRENGTH * 2 : 0);
+  attachable_depth = panel_depth + (units_x > 2 ? BASE_STRENGTH * 2 : 0);
 
   attachable_dimensions = [attachable_width, attachable_depth, attachable_height];
 
-  // Align attachable anchors depending on mount surfaces
-  move_right = (mount_west ? mount_extension/2 : 0) + (mount_east ? -mount_extension/2 : 0);
-  move_fwd = (mount_north ? mount_extension/2 : 0) + (mount_south ? -mount_extension/2 : 0);
 
   // Override BOTTOM anchors for Full Cover to account for base plate XY dimensions
   fullcover_addition = BASE_UNIT - panel_clearance;
@@ -227,11 +221,9 @@ module panel(units_x, units_y, panel_type = HR_PANEL_TYPE_INTERFIT, panel_cleara
   full_cover_depth = units_y * BASE_UNIT + fullcover_addition;
   override = panel_type != HR_PANEL_TYPE_FULLCOVER ? undef : function (anchor)
       anchor.z != -1 ? undef
-      : [[anchor.x * attachable_width/2 + move_right, anchor.y * attachable_depth/2 - move_fwd, -attachable_height/2]];
+      : [[anchor.x * attachable_width/2, anchor.y * attachable_depth/2, -attachable_height/2]];
 
   attachable(anchor, spin, orient, size=attachable_dimensions, override=override) {
-    right(move_right)
-    fwd(move_fwd)
     down(attachable_height/2-BASE_STRENGTH/2)
     color_this(debug_colors ? HR_BLUE : HR_PANEL_PRIMARY_COLOR)
     cuboid([panel_width, panel_depth, BASE_STRENGTH],chamfer=chamfer_enabled ? BASE_CHAMFER : 0, except=TOP){


### PR DESCRIPTION
## 📦 What

- Removed `TOLERANCE/2` from `mount_extension` — attachable bounding box now uses `BASE_STRENGTH * 2` symmetrically
- Removed asymmetric anchor shifting (`move_right`/`move_fwd`) and the `right()`/`fwd()` transforms that moved the panel geometry within the attachable
- Simplified Full Cover `BOTTOM` anchor override to pure `attachable_width/2` without offset

## 💡 Why

Two bugs introduced in #382:

1. **`mount_extension` overlap** — `BASE_STRENGTH + TOLERANCE/2` extended the attachable bounding box by half a tolerance into the scaffold support structure. The support mount's `bottom_plate_width` is `BASE_STRENGTH*2 + TOLERANCE/2`, but only `BASE_STRENGTH` protrudes beyond the base plate edge, so the extra `TOLERANCE/2` was wrong.

2. **Asymmetric anchor shifting** — When a mount plate was disabled (e.g. `mount_north=false`), the bounding box shrank on that side and the geometry was offset to compensate. This kept the panel visually centered but caused `align()` on children to shift inward, defeating the purpose of aligning components precisely onto support_mount_plate positions.

## 🔧 How

No parameter changes — drop-in fix. Anchors are now stable regardless of which mount plates are enabled/disabled. Children aligned to `BOTTOM` edges will always land at the support bar boundary.