### PR TITLE
feat(keystone): add dimensions helper, label plate modes, and shorten inner hooks

### DIFF
--- a/models/keystone/README.md
+++ b/models/keystone/README.md
@@ -61,6 +61,8 @@ cuboid([50, 2, 50]) {
 | `label_recess()` | Front-face recess for label hook snap-fit |
 | `keystone_demo_panel()` | Demo panel strip with one keystone mounted |
 
+`keystone_full()` and `keystone_demo_panel()` accept `label_plate_mode` (`"assembly"` or `"plate"`) and `label_plate_gap` (mm) to control label plate placement for build-plate layouts.
+
 ### Key Functions
 
 | Function | Returns |
@@ -70,6 +72,7 @@ cuboid([50, 2, 50]) {
 | `get_ks_depth_outer()` | Total depth (front lip + body + rear hook) |
 | `get_effective_keystone_width(tol, yrot)` | Width accounting for rotation |
 | `get_effective_keystone_height(tol, yrot)` | Height accounting for rotation |
+| `get_keystone_dimensions(yrot, tol)` | Pocket dimensions `[w, d, h]` accounting for rotation (excludes label recess) |
 
 ## 📸 Catalog
 

--- a/models/keystone/lib/keystone.scad
+++ b/models/keystone/lib/keystone.scad
@@ -79,6 +79,13 @@ function get_effective_keystone_height(additional_tolerance=0.0, yrot=0) =
 function get_label_slot_vertical_offset(yrot=0, additional_tolerance=0.0) =
   yrot == 90 || yrot == 270 ? get_ks_height_outer(additional_tolerance) - get_ks_width_outer(additional_tolerance) : 0;
 
+/// Returns the dimensions [width, depth, height] of a keystone accounting for rotation.
+function get_keystone_dimensions(yrot=0, additional_tolerance=0.0) = [
+  get_effective_keystone_width(additional_tolerance, yrot),
+  get_ks_depth_outer(),
+  get_effective_keystone_height(additional_tolerance, yrot)
+];
+
 /// Returns the total attachable height of the label recess block.
 function get_label_attachable_height(yrot=0, additional_tolerance=0.0) =
   KS_LABEL_HEIGHT + TOLERANCE + get_label_slot_vertical_offset(yrot, additional_tolerance) + BASE_STRENGTH;
@@ -139,8 +146,9 @@ module _label_hook_left(slot_width, slot_depth, slot_height, label_slot_spacing,
     left((label_slot_spacing - slot_width - _spacing_sub) / 2)
     cuboid([slot_width, slot_depth, slot_height], chamfer=_chamfer, edges=[BACK, LEFT], except=FRONT) {
       // Hook tab
+      _hook_height = inner ? slot_height / 2 : slot_height;
       color_this(debug_colors ? HR_GREEN : _color) fwd(_chamfer)
-      align(RIGHT, BACK) cuboid([_hook_width, BASE_STRENGTH - _spacing_sub - _chamfer, slot_height],
+      align(RIGHT, BACK) cuboid([_hook_width, BASE_STRENGTH - _spacing_sub - _chamfer, _hook_height],
         chamfer=_hook_width, edges=RIGHT);
       // Insertion funnel (panel side only)
       if (!inner) {
@@ -251,10 +259,13 @@ module label_recess(additional_tolerance=0.0, yrot=0,
 /// Parameters:
 ///   add_label_slots      - include snap-fit label plate recesses (default: true)
 ///   show_label           - render a label plate in place for preview (default: false)
+///   label_plate_mode     - "assembly": label in front (default); "plate": label above on same plane
+///   label_plate_gap      - extra upward offset for plate mode (mm, default: 0)
 ///   additional_tolerance - extra clearance around the keystone (mm)
 ///   yrot                 - rotation angle: 0, 90, 180, 270 (degrees)
 ///   panel_depth          - depth of the panel being cut into (mm, default: keystone depth)
-module keystone_full(add_label_slots=true, show_label=false, additional_tolerance=0.0, yrot=0,
+module keystone_full(add_label_slots=true, show_label=false, label_plate_mode="assembly",
+  label_plate_gap=0, additional_tolerance=0.0, yrot=0,
   panel_depth, anchor=CENTER, spin=0, orient=UP, debug_colors=false) {
 
   assert(!show_label || add_label_slots,
@@ -273,9 +284,13 @@ module keystone_full(add_label_slots=true, show_label=false, additional_toleranc
     keystone_pocket(additional_tolerance=additional_tolerance, yrot=yrot, panel_depth=_panel_depth, debug_colors=debug_colors) {
       if (add_label_slots) {
         align(TOP, FRONT) label_recess(additional_tolerance=additional_tolerance, yrot=yrot, debug_colors=debug_colors) {
-          if (show_label) {
+          if (show_label && label_plate_mode == "assembly") {
             fwd(BASE_STRENGTH) down(BASE_STRENGTH)
               align(FRONT, TOP) label_plate(yrot=yrot, debug_colors=debug_colors);
+          }
+          if (show_label && label_plate_mode == "plate") {
+            up(KS_LABEL_HEIGHT/2 + TOLERANCE + label_plate_gap)
+              align(TOP) label_plate(yrot=yrot, orient=UP, debug_colors=debug_colors);
           }
         }
       }
@@ -286,19 +301,22 @@ module keystone_full(add_label_slots=true, show_label=false, additional_toleranc
 
 /// Demo panel showing a single keystone mounted in a 1U-height panel strip.
 /// Useful for visualization and testing. Used by the parts/keystone_sample.scad file.
-module keystone_demo_panel(additional_tolerance=0.0, yrot=0, panel_depth, add_label=true, debug_colors=false) {
+module keystone_demo_panel(additional_tolerance=0.0, yrot=0, panel_depth, add_label=true,
+  label_plate_mode="assembly", label_plate_gap=0, debug_colors=false) {
   _panel_depth = is_undef(panel_depth) ? get_ks_depth_outer() : panel_depth;
   _ks_depth = get_ks_depth_outer();
   _width = get_effective_keystone_width(additional_tolerance=additional_tolerance, yrot=yrot);
   _height = STD_UNIT_HEIGHT;
+  _orient = label_plate_mode == "plate" ? FRONT : UP;
 
-  attachable(expose_tags=true, anchor=CENTER, spin=0, axis=UP, orient=UP, size=[_width, _ks_depth, _height]) {
+  attachable(expose_tags=true, anchor=CENTER, spin=0, axis=UP, orient=_orient, size=[_width, _ks_depth, _height]) {
     fwd(_ks_depth / 2 - BASE_STRENGTH / 2)
     diff("keystone")
     color_this(debug_colors ? HR_WHITE : KS_COLOR_PRIMARY)
     cuboid([_width, BASE_STRENGTH, STD_UNIT_HEIGHT]) {
       align(FRONT, BOTTOM, inside=true) {
         keystone_full(add_label_slots=add_label, show_label=add_label,
+          label_plate_mode=label_plate_mode, label_plate_gap=label_plate_gap,
           additional_tolerance=additional_tolerance, yrot=yrot,
           panel_depth=_panel_depth, debug_colors=debug_colors);
       }

--- a/models/keystone/lib/keystone.scad
+++ b/models/keystone/lib/keystone.scad
@@ -79,7 +79,8 @@ function get_effective_keystone_height(additional_tolerance=0.0, yrot=0) =
 function get_label_slot_vertical_offset(yrot=0, additional_tolerance=0.0) =
   yrot == 90 || yrot == 270 ? get_ks_height_outer(additional_tolerance) - get_ks_width_outer(additional_tolerance) : 0;
 
-/// Returns the dimensions [width, depth, height] of a keystone accounting for rotation.
+/// Returns the pocket dimensions [width, depth, height] of a keystone accounting for rotation.
+/// Excludes the label recess — use get_label_attachable_height() for label slot height.
 function get_keystone_dimensions(yrot=0, additional_tolerance=0.0) = [
   get_effective_keystone_width(additional_tolerance, yrot),
   get_ks_depth_outer(),
@@ -268,6 +269,8 @@ module keystone_full(add_label_slots=true, show_label=false, label_plate_mode="a
   label_plate_gap=0, additional_tolerance=0.0, yrot=0,
   panel_depth, anchor=CENTER, spin=0, orient=UP, debug_colors=false) {
 
+  assert(label_plate_mode == "assembly" || label_plate_mode == "plate",
+    str("label_plate_mode must be 'assembly' or 'plate', got: '", label_plate_mode, "'"));
   assert(!show_label || add_label_slots,
     "show_label requires add_label_slots=true");
 
@@ -303,6 +306,8 @@ module keystone_full(add_label_slots=true, show_label=false, label_plate_mode="a
 /// Useful for visualization and testing. Used by the parts/keystone_sample.scad file.
 module keystone_demo_panel(additional_tolerance=0.0, yrot=0, panel_depth, add_label=true,
   label_plate_mode="assembly", label_plate_gap=0, debug_colors=false) {
+  assert(label_plate_mode == "assembly" || label_plate_mode == "plate",
+    str("label_plate_mode must be 'assembly' or 'plate', got: '", label_plate_mode, "'"));
   _panel_depth = is_undef(panel_depth) ? get_ks_depth_outer() : panel_depth;
   _ks_depth = get_ks_depth_outer();
   _width = get_effective_keystone_width(additional_tolerance=additional_tolerance, yrot=yrot);

--- a/models/keystone/test/keystone.scad
+++ b/models/keystone/test/keystone.scad
@@ -31,3 +31,11 @@ label_plate(yrot=0);
 // Demo panel
 right(185)
 keystone_demo_panel(yrot=90, panel_depth=15);
+
+// Plate mode: label above panel
+right(220)
+keystone_full(show_label=true, label_plate_mode="plate", label_plate_gap=15);
+
+// Demo panel in plate mode
+right(255)
+keystone_demo_panel(label_plate_mode="plate", add_label=true);


### PR DESCRIPTION
## 📦 What

- Add `get_keystone_dimensions()` function returning `[width, depth, height]` vector
- Add `label_plate_mode` and `label_plate_gap` params to `keystone_full()` and `keystone_demo_panel()`
- Support `"plate"` mode: orients label plates flat above the panel for build-plate layout
- Shorten inner label hooks (`inner=true`) to half height for easier label plate insertion

## 💡 Why

🔧 `get_keystone_dimensions()` enables downstream assembly modules (keystonepanel) to compute layout without duplicating dimension logic.

🖨️ Plate mode allows rendering label plates on the same build plate as the panel — needed for MakerWorld multi-part exports.

⚡ Shorter inner hooks reduce friction when inserting/removing label plates while the panel-side hooks maintain full grip.

## 🔧 How

```scad
// New dimension helper
dims = get_keystone_dimensions(yrot=90, additional_tolerance=0.1);
// dims = [width, depth, height] accounting for rotation

// Label plate modes
keystone_full(show_label=true, label_plate_mode="assembly"); // default: label in front
keystone_full(show_label=true, label_plate_mode="plate", label_plate_gap=20); // flat above panel

// Demo panel with plate mode
keystone_demo_panel(label_plate_mode="plate", label_plate_gap=15);
```