### PR TITLE
fix(panel): rename lockpin_hole to panel_lockpin_hole to avoid name collision

### DIFF
--- a/models/panel/lib/panel.scad
+++ b/models/panel/lib/panel.scad
@@ -51,10 +51,11 @@ function get_lockpin_hole_offset_vertical(panel_type = HR_PANEL_TYPE_INTERFIT) =
   - BASE_STRENGTH/2
   - TOLERANCE/2;
 
-/** Lockpin Hole — subtracted from mount plates to create the square hole a lockpin slides into.
+/** Panel Lockpin Hole — subtracted from mount plates to create the square hole a lockpin slides into.
 Includes an optional chamfer on the insertion side for easier pin alignment.
+This is the shallow panel-side passthrough; distinct from the core lockpin_hole(depth=...) reusable cavity.
 */
-module lockpin_hole(anchor=CENTER, spin=0, orient=UP, debug_colors=false, chamfer_enabled=false) {
+module panel_lockpin_hole(anchor=CENTER, spin=0, orient=UP, debug_colors=false, chamfer_enabled=false) {
 
   lockpin_hole_dimensions = [LOCKPIN_HOLE_SIDE_LENGTH, BASE_STRENGTH, LOCKPIN_HOLE_SIDE_LENGTH];
   lockpin_chamfer_dimensions = [LOCKPIN_HOLE_SIDE_LENGTH + LOCKPIN_HOLE_CHAMFER*2, LOCKPIN_HOLE_CHAMFER, LOCKPIN_HOLE_SIDE_LENGTH + LOCKPIN_HOLE_CHAMFER*2];
@@ -88,7 +89,7 @@ module connector_mount_plate(panel_type=HR_PANEL_TYPE_INTERFIT, anchor=CENTER, s
       if(full) {
         down(lockpin_hole_offset_vertical) left(lockpin_hole_offset_horizontal)
         attach(FRONT,FRONT, inside=true)
-        tag("remove") lockpin_hole(debug_colors=debug_colors, chamfer_enabled=chamfer_enabled);
+        tag("remove") panel_lockpin_hole(debug_colors=debug_colors, chamfer_enabled=chamfer_enabled);
       }
       if(inner_chamfer && full) {
         inner_chamfer_length = plate_height - BASE_CHAMFER;
@@ -139,7 +140,7 @@ module support_mount_plate(panel_type=HR_PANEL_TYPE_INTERFIT, units, anchor=CENT
       align(TOP,LEFT) color_this(debug_colors ? HR_GREEN : HR_PANEL_PRIMARY_COLOR) diff() cuboid([wall_width, wall_depth, wall_height],chamfer=chamfer_enabled ? BASE_CHAMFER : 0,edges=[LEFT,TOP],except=[BOTTOM,RIGHT]){
         down(lockpin_hole_offset_vertical)
         attach(LEFT,BACK,inside=true)
-        xcopies(spacing=BASE_UNIT, n=net_units) lockpin_hole(debug_colors=debug_colors, chamfer_enabled=chamfer_enabled);
+        xcopies(spacing=BASE_UNIT, n=net_units) panel_lockpin_hole(debug_colors=debug_colors, chamfer_enabled=chamfer_enabled);
       }
       color(debug_colors ? HR_GREEN : HR_PANEL_PRIMARY_COLOR)
       align(TOP,RIGHT+BACK) diff() cuboid(bridge_dimensions) {
@@ -246,7 +247,7 @@ module panel(units_x, units_y, panel_type = HR_PANEL_TYPE_INTERFIT, panel_cleara
           color_this(wall_color) align(TOP,BACK) diff() cuboid(h_wall, chamfer=wall_chamfer_size, edges=[BACK+TOP]){
             if(panel_type == HR_PANEL_TYPE_INTERFIT)
               tag("remove") down(lockpin_hole_offset_vertical) attach(BACK,BACK,inside=true)
-                xcopies(spacing=BASE_UNIT, n=net_units_x) lockpin_hole(debug_colors=debug_colors, chamfer_enabled=chamfer_enabled);
+                xcopies(spacing=BASE_UNIT, n=net_units_x) panel_lockpin_hole(debug_colors=debug_colors, chamfer_enabled=chamfer_enabled);
           }
         }
         if(mount_south) {
@@ -256,7 +257,7 @@ module panel(units_x, units_y, panel_type = HR_PANEL_TYPE_INTERFIT, panel_cleara
           color_this(wall_color) align(TOP,FRONT) diff() cuboid(h_wall, chamfer=wall_chamfer_size, edges=[TOP+FRONT]){
             if(panel_type == HR_PANEL_TYPE_INTERFIT)
               tag("remove") down(lockpin_hole_offset_vertical) attach(FRONT,BACK,inside=true)
-                xcopies(spacing=BASE_UNIT, n=net_units_x) lockpin_hole(debug_colors=debug_colors, chamfer_enabled=chamfer_enabled);
+                xcopies(spacing=BASE_UNIT, n=net_units_x) panel_lockpin_hole(debug_colors=debug_colors, chamfer_enabled=chamfer_enabled);
           }
         }
       }
@@ -270,7 +271,7 @@ module panel(units_x, units_y, panel_type = HR_PANEL_TYPE_INTERFIT, panel_cleara
           color_this(wall_color) align(TOP,LEFT) diff() cuboid(v_wall, chamfer=wall_chamfer_size, edges=[LEFT+TOP]){
             if(panel_type == HR_PANEL_TYPE_INTERFIT)
               tag("remove") down(lockpin_hole_offset_vertical) attach(LEFT,BACK,inside=true)
-                xcopies(spacing=BASE_UNIT, n=net_units_y) lockpin_hole(debug_colors=debug_colors, chamfer_enabled=chamfer_enabled);
+                xcopies(spacing=BASE_UNIT, n=net_units_y) panel_lockpin_hole(debug_colors=debug_colors, chamfer_enabled=chamfer_enabled);
           }
         }
         if(mount_east) {
@@ -280,7 +281,7 @@ module panel(units_x, units_y, panel_type = HR_PANEL_TYPE_INTERFIT, panel_cleara
           color_this(wall_color) align(TOP,RIGHT) diff() cuboid(v_wall, chamfer=wall_chamfer_size, edges=[TOP+RIGHT]){
             if(panel_type == HR_PANEL_TYPE_INTERFIT)
               tag("remove") down(lockpin_hole_offset_vertical) attach(RIGHT,BACK,inside=true)
-                xcopies(spacing=BASE_UNIT, n=net_units_y) lockpin_hole(debug_colors=debug_colors, chamfer_enabled=chamfer_enabled);
+                xcopies(spacing=BASE_UNIT, n=net_units_y) panel_lockpin_hole(debug_colors=debug_colors, chamfer_enabled=chamfer_enabled);
           }
         }
       }

--- a/models/panel/test/lockpin_collision.scad
+++ b/models/panel/test/lockpin_collision.scad
@@ -1,0 +1,22 @@
+// HomeRacker - Panel lockpin name-collision regression test
+//
+// Guards the panel_lockpin_hole rename. panel.scad's shallow mount-hole module used to be
+// named lockpin_hole, colliding with the reusable core lockpin_hole(depth=...) (core/lib/
+// lockpin.scad). When both ended up in scope together — e.g. a model that includes panel.scad
+// alongside split.scad (which includes core lockpin) — the core module shadowed the panel one,
+// so panel mount holes rendered with depth=undef and tripped is_vector(size,3).
+//
+// Here we deliberately put BOTH modules in scope (panel.scad first, then core lockpin last so
+// the core definition wins any collision) and render panels whose mounts exercise the panel-side
+// holes. Pre-rename this aborts; post-rename it renders cleanly.
+
+include <../lib/panel.scad>
+include <../../core/lib/lockpin.scad>
+
+// Full-cover panel: corner connector mounts subtract panel_lockpin_hole.
+panel(4, 4, HR_PANEL_TYPE_FULLCOVER);
+
+// Inter-fit panel with open edges: edge walls subtract panel_lockpin_hole rows.
+right(120)
+panel(4, 4, HR_PANEL_TYPE_INTERFIT,
+  mount_north=false, mount_south=false, mount_east=false, mount_west=false);


### PR DESCRIPTION
## 📦 What

Rename the **panel-local** `lockpin_hole` module to `panel_lockpin_hole` in [`models/panel/lib/panel.scad`](models/panel/lib/panel.scad) (definition + 6 internal call sites), and add a regression test that puts both this and the reusable `core/lib/lockpin.scad`'s `lockpin_hole(depth=…)` in scope at once.

## 💡 Why

Two `lockpin_hole` modules quietly coexisted in homeracker:

| File | Signature | Purpose |
|---|---|---|
| `models/panel/lib/panel.scad` | `lockpin_hole(anchor, spin, orient, debug_colors, chamfer_enabled)` | Shallow panel-side passthrough for mount plates |
| `models/core/lib/lockpin.scad` (refactor 4495128) | `lockpin_hole(depth, chamfer_top, chamfer_bottom, …)` | Reusable cavity sized for a full lockpin |

As long as no model pulled both into the same scope, neither knew about the other. But when a downstream model `include`s `panel.scad` alongside `split.scad` (which transitively `include`s `core/lib/lockpin.scad`), the core module wins the name collision, panel.scad's own depth-less calls then run with `depth = undef`, and the render aborts:

```
ERROR: Assertion 'is_vector(size, 3)' failed in BOSL2/attachments.scad
TRACE: lockpin_hole(depth = undef, ...) in core/lib/lockpin.scad:271
TRACE: lockpin_hole(debug_colors=..., chamfer_enabled=...) in panel.scad:91
```

⚠ Homeracker's own tests didn't catch this because no current homeracker test combines `panel()` mounts with `split.scad` in scope — `rackpanel.scad` deliberately doesn't include `split.scad` (to avoid a circular include). The first model to hit it is the downstream `homeracker-exclusive/keystonepanel`, where the keystone panel includes `panel.scad`, `rackpanel.scad`, `split.scad`, and `keystone.scad` together and crashes every keystone grid/strip render.

Renaming the panel-local module is the lowest-blast-radius fix: it's defined and used in a single file (panel.scad), whereas the core `lockpin_hole(depth=…)` is the deliberately-extracted reusable API consumed by `connector`, `sleeve`, `supportgrid`, etc. — renaming **that** would ripple across many models.

## 🔧 How

- Rename module: `lockpin_hole(…)` → `panel_lockpin_hole(…)` in [`models/panel/lib/panel.scad`](models/panel/lib/panel.scad) (def + 6 call sites at lines 91, 142, 249, 259, 273, 283).
- Doc comment updated to note the distinction from `core/lib/lockpin.scad`'s `lockpin_hole(depth=…)`.
- New regression test [`models/panel/test/lockpin_collision.scad`](models/panel/test/lockpin_collision.scad) deliberately puts both modules in scope and renders a `FULLCOVER` panel (exercises `connector_mount_plate`) and an open-edge `INTERFIT` panel (exercises edge-wall `panel_lockpin_hole` rows).

### ✅ Verification

| Test | Result |
|---|---|
| New `lockpin_collision.scad` — **before** rename | ❌ `is_vector(size,3)` (reproduces the bug) |
| New `lockpin_collision.scad` — **after** rename | ✅ NoError |
| Existing `panel.scad` / `rackpanel.scad` / `split.scad` tests | ✅ NoError (no regression) |
| `homeracker-exclusive/keystonepanel` `keystonegrid` + `keystonestrip` (with patched lib) | ✅ NoError (unblocks downstream) |
| Pre-commit | ✅ Passed |

No public API change — `panel_lockpin_hole` is panel-internal; the reusable `core/lib/lockpin.scad`'s `lockpin_hole(depth=…)` is untouched.