### PR TITLE
docs(agent): fix exclusive collection name and Core link in description template

### DIFF
--- a/.github/agents/makerworld-description.agent.md
+++ b/.github/agents/makerworld-description.agent.md
@@ -122,7 +122,7 @@ Or simply scan this QR-Code:
 **For homeracker-exclusive models** (private repo): add a note linking to the Core changelog since the exclusive repo isn't public:
 
 ```markdown
-This model is part of the [HomeRacker Exclusive](https://makerworld.com/en/@kellerlab) collection. It builds on the open-source [HomeRacker - Core](https://makerworld.com/en/models/1317298-homeracker-modular-rack-building-system#profileId-1352703) system — the base building blocks changelog can be found in the [Core CHANGELOG](https://github.com/kellerlabs/homeracker/blob/main/CHANGELOG.md).
+This model is part of the [MakerWorld-exclusive HomeRacker collection](https://makerworld.com/en/collections/5970240-homeracker-official-catalog). It builds on the open-source [HomeRacker - Core](https://github.com/kellerlabs/homeracker/tree/main/models) system — the base building blocks changelog can be found in the [Core CHANGELOG](https://github.com/kellerlabs/homeracker/blob/main/CHANGELOG.md).
 ```
 
 **For homeracker models** (public repo): link directly to the full changelog:


### PR DESCRIPTION
## 📦 What

Updates the `makerworld-description` agent's footer template for **homeracker-exclusive** model descriptions:

- 🏷️ Renames the collection from `HomeRacker Exclusive` → **MakerWorld-exclusive HomeRacker collection**, now linking the [official catalog](https://makerworld.com/en/collections/5970240-homeracker-official-catalog) instead of the `@kellerlab` profile.
- 🔗 Points the open-source **HomeRacker - Core** link at the [GitHub repo](https://github.com/kellerlabs/homeracker/tree/main/models) instead of the MakerWorld model page.

## 💡 Why

The footer template was the hardcoded source that propagated the wrong collection name/link into every generated exclusive description. Fixing it here stops the mistake from recurring in future model descriptions. The matching fix was already applied to the existing exclusive descriptions (keystonepanel, foot, racklink) in the homeracker-exclusive repo.

## 🔧 How

No action needed — the agent picks up the corrected template automatically on the next description it generates. ✅