### PR TITLE
fix(panel): keep one uniform color when mount plates are removed

### DIFF
--- a/models/panel/lib/panel.scad
+++ b/models/panel/lib/panel.scad
@@ -94,6 +94,7 @@ module connector_mount_plate(panel_type=HR_PANEL_TYPE_INTERFIT, anchor=CENTER, s
       if(inner_chamfer && full) {
         inner_chamfer_length = plate_height - BASE_CHAMFER;
         tag("remove")
+        color_this(debug_colors ? HR_RED : HR_PANEL_PRIMARY_COLOR)
         edge_mask(RIGHT+BACK)
           up(BASE_CHAMFER/2)
           chamfer_edge_mask(l=inner_chamfer_length, chamfer=BASE_CHAMFER);


### PR DESCRIPTION
## 📦 What

Color the full-cover inner-chamfer `edge_mask` cutter in `connector_mount_plate` (panel lib) with the primary color. One-line change in [models/panel/lib/panel.scad](models/panel/lib/panel.scad).

## 💡 Why

In **non-debug** mode, removing a mount plate (e.g. `mount_south=false`) on a Full-Cover panel changed the panel's color. 🐛 The exported 3MF ended up **multi-material**, so Bambu Studio treated it as a painted object and blocked recoloring.

Root cause: the inner-chamfer `edge_mask` sits under a `color_this()` parent, which does **not** propagate to children — so the `tag("remove")` cutter was uncolored. The face it exposed after `diff()` inherited a stray color (a greenish `#9DCB51`), producing extra materials in the export.

## 🔧 How

- ✅ Verified via 3MF export sweep: before, `mount_south=false` had 6 triangles on a stray `#9DCB51` material; after, **all triangles export as a single uniform `#F7B600`** (HR_YELLOW).
- ✅ `models/panel/test/panel.scad` renders with `NoError`.
- ✅ Pre-commit hooks pass (flatten validation, formatting).

No geometry change — only the color assigned to the exposed chamfer face.