### PR TITLE
feat(scadm): parallelize model rendering

### DIFF
--- a/cmd/scadm/README.md
+++ b/cmd/scadm/README.md
@@ -161,7 +161,12 @@ scadm render --source
 
 # Both at once
 scadm render --source --flattened
+
+# Control parallelism (default: number of CPU cores)
+scadm render --flattened -j 4
 ```
+
+Renders run in parallel by default, using one thread per CPU core. Use `-j`/`--jobs` to override the worker count (e.g. `-j 1` for sequential execution, `-j 4` to cap at 4 workers).
 
 The `--source` and `--flattened` flags discover files from `scadm.json` `"flatten"` entries automatically. They cannot be combined with explicit file arguments.
 

--- a/cmd/scadm/scadm/cli.py
+++ b/cmd/scadm/scadm/cli.py
@@ -105,7 +105,7 @@ def _handle_render(args, render_parser):
         else:
             files = [f.resolve() for f in args.files]
 
-        sys.exit(0 if render_files(files) else 1)
+        sys.exit(0 if render_files(files, max_workers=args.jobs) else 1)
     except (FileNotFoundError, ValueError) as e:
         logger.error("%s", e)
         sys.exit(1)
@@ -192,6 +192,13 @@ def main():
     )
     render_parser.add_argument(
         "--flattened", action="store_true", help="Render flattened output files from scadm.json flatten dest dirs"
+    )
+    render_parser.add_argument(
+        "-j",
+        "--jobs",
+        type=int,
+        default=None,
+        help="Number of parallel render workers (default: CPU count)",
     )
 
     # Export-PNG command

--- a/cmd/scadm/scadm/render.py
+++ b/cmd/scadm/scadm/render.py
@@ -4,6 +4,7 @@ Finds the bundled OpenSCAD binary, sets OPENSCADPATH to the installed libraries,
 and runs a render-to-STL to validate syntax and geometry.
 """
 
+import concurrent.futures
 import logging
 import os
 import shutil
@@ -78,12 +79,17 @@ def render_file(scad_file: Path, workspace_root: Optional[Path] = None) -> bool:
         output_file.unlink(missing_ok=True)
 
 
-def render_files(files: list[Path], workspace_root: Optional[Path] = None) -> bool:
-    """Render multiple .scad files.
+def render_files(
+    files: list[Path],
+    workspace_root: Optional[Path] = None,
+    max_workers: Optional[int] = None,
+) -> bool:
+    """Render multiple .scad files in parallel.
 
     Args:
         files: List of .scad file paths.
         workspace_root: Project root (auto-detected if None).
+        max_workers: Max parallel renders. Defaults to os.cpu_count().
 
     Returns:
         True if all renders succeeded.
@@ -91,10 +97,18 @@ def render_files(files: list[Path], workspace_root: Optional[Path] = None) -> bo
     if workspace_root is None:
         workspace_root = get_workspace_root()
 
+    if max_workers is None:
+        max_workers = os.cpu_count() or 1
+
+    workers = min(max_workers, len(files))
+    logger.info("Rendering %d file(s) with %d worker(s)", len(files), workers)
+
     failed = 0
-    for f in files:
-        if not render_file(f, workspace_root):
-            failed += 1
+    with concurrent.futures.ThreadPoolExecutor(max_workers=workers) as executor:
+        futures = {executor.submit(render_file, f, workspace_root): f for f in files}
+        for future in concurrent.futures.as_completed(futures):
+            if not future.result():
+                failed += 1
 
     if failed:
         logger.error("%d render(s) failed", failed)

--- a/cmd/scadm/scadm/render.py
+++ b/cmd/scadm/scadm/render.py
@@ -99,6 +99,8 @@ def render_files(
 
     if max_workers is None:
         max_workers = os.cpu_count() or 1
+    elif max_workers < 1:
+        raise ValueError(f"--jobs must be at least 1, got {max_workers}")
 
     workers = min(max_workers, len(files))
     logger.info("Rendering %d file(s) with %d worker(s)", len(files), workers)

--- a/cmd/scadm/tests/test_render.py
+++ b/cmd/scadm/tests/test_render.py
@@ -4,8 +4,9 @@ import json
 import tempfile
 import unittest
 from pathlib import Path
+from unittest.mock import patch
 
-from scadm.render import discover_flatten_files
+from scadm.render import discover_flatten_files, render_files
 
 
 class DiscoverFlattenFilesTests(unittest.TestCase):
@@ -165,6 +166,41 @@ class DiscoverFlattenFilesTests(unittest.TestCase):
             (root / "scadm.json").write_text("{invalid json", encoding="utf-8")
             with self.assertRaises(ValueError):
                 discover_flatten_files(root, source=True)
+
+
+class RenderFilesTests(unittest.TestCase):
+    @patch("scadm.render.render_file", return_value=True)
+    @patch("scadm.render.get_workspace_root", return_value=Path("/fake"))
+    def test_all_pass_returns_true(self, _mock_root, mock_render):
+        """Returns True when all renders succeed."""
+        files = [Path("a.scad"), Path("b.scad"), Path("c.scad")]
+        self.assertTrue(render_files(files, max_workers=2))
+        self.assertEqual(mock_render.call_count, 3)
+
+    @patch("scadm.render.render_file", side_effect=[True, False, True])
+    @patch("scadm.render.get_workspace_root", return_value=Path("/fake"))
+    def test_partial_failure_returns_false(self, _mock_root, _mock_render):
+        """Returns False when any render fails."""
+        files = [Path("a.scad"), Path("b.scad"), Path("c.scad")]
+        self.assertFalse(render_files(files, max_workers=1))
+
+    def test_zero_jobs_raises(self):
+        """Raises ValueError for max_workers=0."""
+        with self.assertRaises(ValueError, msg="--jobs must be at least 1"):
+            render_files([Path("a.scad")], workspace_root=Path("/fake"), max_workers=0)
+
+    def test_negative_jobs_raises(self):
+        """Raises ValueError for negative max_workers."""
+        with self.assertRaises(ValueError, msg="--jobs must be at least 1"):
+            render_files([Path("a.scad")], workspace_root=Path("/fake"), max_workers=-1)
+
+    @patch("scadm.render.render_file", return_value=True)
+    @patch("scadm.render.get_workspace_root", return_value=Path("/fake"))
+    def test_workers_capped_to_file_count(self, _mock_root, mock_render):
+        """Workers are capped to file count even if max_workers is higher."""
+        files = [Path("a.scad"), Path("b.scad")]
+        self.assertTrue(render_files(files, max_workers=100))
+        self.assertEqual(mock_render.call_count, 2)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary

Parallelizes `scadm render` using `concurrent.futures.ThreadPoolExecutor`, defaulting to `os.cpu_count()` workers. Each render is an independent OpenSCAD subprocess, so threads are ideal (no GIL contention).

### Changes
- **render.py**: `render_files()` now uses a thread pool instead of a sequential loop. New `max_workers` parameter.
- **cli.py**: Added `-j` / `--jobs` flag to `scadm render` subcommand.

### Benchmark (23 models, 32 logical cores)

| Mode | Time | Speedup |
|------|------|---------|
| Sequential (baseline) | 86.6s | 1x |
| Parallel (23 workers) | 31.8s | **2.72x** |

GitHub hosted runners (typically 4 cores) should also see a meaningful improvement since many models render in under 2s and would otherwise bottleneck behind larger ones like `split.scad` (~28s) and `panel.scad` (~13s).