### PR TITLE
feat: make Dirnei codeowner of configurator and site

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,6 +1,10 @@
 # Default owner for everything
 * @kellervater
 
+# Web configurator and site
+/configurator/ @kellervater @Dirnei
+/site/ @kellervater @Dirnei
+
 # Release files can be approved by release bot
 CHANGELOG.md
 .release-please-manifest.json


### PR DESCRIPTION
## 📌 What

`@Dirnei` joins `@kellervater` as codeowner of `/configurator/` and `/site/`.

## 🤔 Why

He built both in #460 and has write access, so changes there should reach him.

## 📝 Note

`main` is currently unprotected, so codeowner review is advisory until a ruleset requires it.
