### PR TITLE
feat(site): serve the site from a configurable base path

### DIFF
--- a/site/astro.config.mjs
+++ b/site/astro.config.mjs
@@ -4,6 +4,9 @@ import { rehypeRepoLinks, rehypeSections } from "./src/lib/rehype.ts";
 
 export default defineConfig({
   site: "https://homeracker.org",
+  // Preview deployments are served from a subpath, so every internal link and public asset
+  // reference has to go through import.meta.env.BASE_URL rather than a leading slash.
+  base: process.env.SITE_BASE ?? "/",
   outDir: "dist",
   trailingSlash: "always",
   image: {

--- a/site/package.json
+++ b/site/package.json
@@ -10,6 +10,7 @@
     "dev": "astro dev",
     "parts": "node scripts/export-parts.mjs",
     "build": "node scripts/export-parts.mjs && astro build",
+    "build:site": "astro build",
     "preview": "astro preview",
     "test": "vitest run",
     "lint": "astro check",

--- a/site/src/components/Hero.astro
+++ b/site/src/components/Hero.astro
@@ -12,7 +12,7 @@
         into whatever shape you need today, and get rebuilt when that changes.
       </p>
       <div class="actions">
-        <a class="button primary" href="/configurator/">Plan your rack</a>
+        <a class="button primary" href={`${import.meta.env.BASE_URL}configurator/`}>Plan your rack</a>
         <a class="button" href="https://makerworld.com/en/models/1317298-homeracker-core" target="_blank" rel="noopener">Get the core model</a>
       </div>
     </div>

--- a/site/src/components/Nav.astro
+++ b/site/src/components/Nav.astro
@@ -2,10 +2,11 @@
 import { Image } from "astro:assets";
 
 const LOGO = "https://raw.githubusercontent.com/kellerlabs/assets/main/homeracker/img/homeracker_logo.png";
+const base = import.meta.env.BASE_URL;
 const links = [
-  { href: "/", label: "Home" },
-  { href: "/models/", label: "Models" },
-  { href: "/configurator/", label: "Configurator" },
+  { href: base, label: "Home" },
+  { href: `${base}models/`, label: "Models" },
+  { href: `${base}configurator/`, label: "Configurator" },
 ];
 const external = [
   { href: "https://github.com/kellerlabs/homeracker", label: "GitHub" },
@@ -17,7 +18,7 @@ const current = Astro.url.pathname;
 
 <header class="nav">
   <div class="wrap bar">
-    <a class="brand" href="/">
+    <a class="brand" href={base}>
       <Image class="mark" src={LOGO} alt="" width={64} height={64} loading="eager" />
       HomeRacker
     </a>

--- a/site/src/layouts/Base.astro
+++ b/site/src/layouts/Base.astro
@@ -10,6 +10,9 @@ interface Props {
   app?: boolean;
 }
 const { title, description, app = false } = Astro.props;
+const base = import.meta.env.BASE_URL;
+// Anything not served from the site root is a PR preview and must stay out of search results.
+const isPreview = base !== "/";
 ---
 
 <!doctype html>
@@ -19,8 +22,9 @@ const { title, description, app = false } = Astro.props;
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>{title}</title>
     <meta name="description" content={description} />
-    <link rel="icon" href="/favicon.ico" />
+    <link rel="icon" href={`${base}favicon.ico`} />
     <link rel="canonical" href={new URL(Astro.url.pathname, Astro.site)} />
+    {isPreview && <meta name="robots" content="noindex, nofollow" />}
     <meta property="og:title" content={title} />
     <meta property="og:description" content={description} />
     <meta property="og:image" content="https://raw.githubusercontent.com/kellerlabs/assets/main/homeracker/img/homeracker_logo.png" />

--- a/site/src/lib/hero.ts
+++ b/site/src/lib/hero.ts
@@ -131,7 +131,7 @@ async function loadParts(manifest: Manifest): Promise<Record<Kind, BufferGeometr
     (Object.keys(FILES) as Kind[]).map(async (kind) => {
       const entry = manifest.parts[FILES[kind]];
       if (!entry) throw new Error(`part ${FILES[kind]} missing from manifest`);
-      const geometry = await loader.loadAsync(`/parts/${entry.file}`);
+      const geometry = await loader.loadAsync(`${import.meta.env.BASE_URL}parts/${entry.file}`);
       geometry.computeVertexNormals();
       return [kind, geometry] as const;
     }),
@@ -208,7 +208,7 @@ function mountExplodedCube(canvas: HTMLCanvasElement, parts: Part[]): void {
 /** Exploded 3D3W cube from the real part meshes; falls back to the schematic rack when they are missing. */
 export async function mountHero(canvas: HTMLCanvasElement): Promise<void> {
   try {
-    const response = await fetch("/parts/manifest.json", { cache: "no-cache" });
+    const response = await fetch(`${import.meta.env.BASE_URL}parts/manifest.json`, { cache: "no-cache" });
     if (!response.ok) throw new Error(`no parts manifest (${response.status})`);
     const manifest = (await response.json()) as Manifest;
     const geometries = await loadParts(manifest);

--- a/site/src/lib/links.ts
+++ b/site/src/lib/links.ts
@@ -12,18 +12,21 @@ function resolveRepoPath(href: string, sourcePath: string): string {
   return parts.join("/");
 }
 
-/** Rewrite a markdown link target so it points at a site page, or at GitHub when the site has no page for it. */
-export function rewriteHref(href: string, sourcePath: string): string {
+/**
+ * Rewrite a markdown link target so it points at a site page, or at GitHub when the site has no
+ * page for it. `base` is the site's mount point and must end in a slash.
+ */
+export function rewriteHref(href: string, sourcePath: string, base = "/"): string {
   if (/^([a-z]+:|#|\/)/i.test(href)) return href;
   const [pathPart, anchor] = href.split("#");
   const repoPath = resolveRepoPath(pathPart ?? "", sourcePath);
   const suffix = anchor ? `#${anchor}` : "";
   const trailingDir = (pathPart ?? "").endsWith("/");
 
-  if (repoPath === "README.md" || repoPath === "") return `/${suffix}`;
-  if (repoPath === "models/README.md" || repoPath === "models") return `/models/${suffix}`;
-  if (repoPath === "configurator/README.md" || repoPath === "configurator") return `/configurator/${suffix}`;
+  if (repoPath === "README.md" || repoPath === "") return `${base}${suffix}`;
+  if (repoPath === "models/README.md" || repoPath === "models") return `${base}models/${suffix}`;
+  if (repoPath === "configurator/README.md" || repoPath === "configurator") return `${base}configurator/${suffix}`;
   const model = repoPath.match(/^models\/([^/]+)(\/README\.md)?$/);
-  if (model && (model[2] || trailingDir)) return `/models/${model[1]}/${suffix}`;
+  if (model && (model[2] || trailingDir)) return `${base}models/${model[1]}/${suffix}`;
   return `${GITHUB_BLOB}${repoPath}${suffix}`;
 }

--- a/site/src/lib/links.ts
+++ b/site/src/lib/links.ts
@@ -13,8 +13,17 @@ function resolveRepoPath(href: string, sourcePath: string): string {
 }
 
 /**
+ * A mount point with exactly one leading and trailing slash. Astro normalises its own `base`, so
+ * this keeps links written here identical to the ones Astro generates from the same raw value.
+ */
+function mountPoint(base: string): string {
+  const trimmed = base.replace(/^\/+|\/+$/g, "");
+  return trimmed ? `/${trimmed}/` : "/";
+}
+
+/**
  * Rewrite a markdown link target so it points at a site page, or at GitHub when the site has no
- * page for it. `base` is the site's mount point and must end in a slash.
+ * page for it. `base` is the site's mount point, in any slash spelling.
  */
 export function rewriteHref(href: string, sourcePath: string, base = "/"): string {
   if (/^([a-z]+:|#|\/)/i.test(href)) return href;
@@ -22,11 +31,12 @@ export function rewriteHref(href: string, sourcePath: string, base = "/"): strin
   const repoPath = resolveRepoPath(pathPart ?? "", sourcePath);
   const suffix = anchor ? `#${anchor}` : "";
   const trailingDir = (pathPart ?? "").endsWith("/");
+  const mount = mountPoint(base);
 
-  if (repoPath === "README.md" || repoPath === "") return `${base}${suffix}`;
-  if (repoPath === "models/README.md" || repoPath === "models") return `${base}models/${suffix}`;
-  if (repoPath === "configurator/README.md" || repoPath === "configurator") return `${base}configurator/${suffix}`;
+  if (repoPath === "README.md" || repoPath === "") return `${mount}${suffix}`;
+  if (repoPath === "models/README.md" || repoPath === "models") return `${mount}models/${suffix}`;
+  if (repoPath === "configurator/README.md" || repoPath === "configurator") return `${mount}configurator/${suffix}`;
   const model = repoPath.match(/^models\/([^/]+)(\/README\.md)?$/);
-  if (model && (model[2] || trailingDir)) return `${base}models/${model[1]}/${suffix}`;
+  if (model && (model[2] || trailingDir)) return `${mount}models/${model[1]}/${suffix}`;
   return `${GITHUB_BLOB}${repoPath}${suffix}`;
 }

--- a/site/src/lib/rehype.ts
+++ b/site/src/lib/rehype.ts
@@ -7,6 +7,9 @@ import { rewriteHref } from "./links";
 import { demoteHeadings, sectionize, type SectionizeOptions } from "./sections";
 
 const REPO_ROOT = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "../../..");
+// Read from the environment rather than import.meta.env: rehype plugins run in Node during the
+// build, outside the client bundle Vite injects BASE_URL into. Mirrors base in astro.config.mjs.
+const BASE = process.env.SITE_BASE ?? "/";
 
 /** Rewrite relative markdown links to site routes or GitHub, based on the file being rendered. */
 export function rehypeRepoLinks() {
@@ -14,7 +17,7 @@ export function rehypeRepoLinks() {
     const sourcePath = path.relative(REPO_ROOT, file.path ?? "").split(path.sep).join("/");
     visit(tree, "element", (node) => {
       if (node.tagName !== "a" || typeof node.properties.href !== "string") return;
-      node.properties.href = rewriteHref(node.properties.href, sourcePath);
+      node.properties.href = rewriteHref(node.properties.href, sourcePath, BASE);
       if (/^https?:/.test(node.properties.href)) {
         node.properties.target = "_blank";
         node.properties.rel = ["noopener"];

--- a/site/src/pages/configurator.astro
+++ b/site/src/pages/configurator.astro
@@ -16,7 +16,7 @@ import Base from "../layouts/Base.astro";
   import { mountConfigurator } from "../../../configurator/src/app";
 
   const root = document.querySelector<HTMLElement>("#configurator");
-  if (root) mountConfigurator(root, { partsUrl: "/parts/" });
+  if (root) mountConfigurator(root, { partsUrl: `${import.meta.env.BASE_URL}parts/` });
 </script>
 
 <style>

--- a/site/src/pages/models/[slug].astro
+++ b/site/src/pages/models/[slug].astro
@@ -16,7 +16,7 @@ const description = model.body?.match(/## 📌 What\s+([^\n]+)/)?.[1] ?? `HomeRa
 <Base title={`${title} – HomeRacker models`} description={description}>
   <div class="wrap page">
     <nav class="crumbs" aria-label="Breadcrumb">
-      <a href="/models/">Models</a>
+      <a href={`${import.meta.env.BASE_URL}models/`}>Models</a>
       <span aria-hidden="true">/</span>
       <span>{model.id}</span>
     </nav>

--- a/site/src/pages/models/index.astro
+++ b/site/src/pages/models/index.astro
@@ -31,7 +31,7 @@ const renderFor = (image: string | null) => (image ? renders[`../../../../models
           const render = renderFor(card.image);
           return (
             <li class:list={["card", { deprecated: card.deprecated }]}>
-              <a href={`/models/${card.slug}/`}>
+              <a href={`${import.meta.env.BASE_URL}models/${card.slug}/`}>
                 <div class="thumb">
                   {render ? <Image src={render} alt={`${card.title} render`} width={480} /> : <span class="none">no render</span>}
                 </div>

--- a/site/tests/links.test.ts
+++ b/site/tests/links.test.ts
@@ -23,6 +23,20 @@ describe("rewriteHref", () => {
     expect(rewriteHref("configurator/README.md", "README.md")).toBe("/configurator/");
   });
 
+  test("mounts site routes under a preview base", () => {
+    const base = "/preview/pr-42/";
+    expect(rewriteHref("models/core/README.md", "README.md", base)).toBe("/preview/pr-42/models/core/");
+    expect(rewriteHref("../README.md", "models/core/README.md", base)).toBe("/preview/pr-42/models/");
+    expect(rewriteHref("configurator/README.md", "README.md", base)).toBe("/preview/pr-42/configurator/");
+    expect(rewriteHref("../../README.md#-tech-specs", "models/core/README.md", base)).toBe("/preview/pr-42/#-tech-specs");
+  });
+
+  test("leaves github fallbacks unprefixed under a preview base", () => {
+    expect(rewriteHref("CONTRIBUTING.md", "README.md", "/preview/pr-42/")).toBe(
+      "https://github.com/kellerlabs/homeracker/blob/main/CONTRIBUTING.md",
+    );
+  });
+
   test("sends everything else to github", () => {
     expect(rewriteHref("CONTRIBUTING.md", "README.md")).toBe("https://github.com/kellerlabs/homeracker/blob/main/CONTRIBUTING.md");
     expect(rewriteHref("../../docs/decisions/x.md", "models/panel/README.md")).toBe(

--- a/site/tests/links.test.ts
+++ b/site/tests/links.test.ts
@@ -31,6 +31,15 @@ describe("rewriteHref", () => {
     expect(rewriteHref("../../README.md#-tech-specs", "models/core/README.md", base)).toBe("/preview/pr-42/#-tech-specs");
   });
 
+  test("normalises any slash spelling of the base, matching what astro does with the same value", () => {
+    for (const base of ["/preview/pr-42/", "/preview/pr-42", "preview/pr-42", "//preview/pr-42//"]) {
+      expect(rewriteHref("models/core/README.md", "README.md", base)).toBe("/preview/pr-42/models/core/");
+    }
+    for (const base of ["/", "", "//"]) {
+      expect(rewriteHref("models/core/README.md", "README.md", base)).toBe("/models/core/");
+    }
+  });
+
   test("leaves github fallbacks unprefixed under a preview base", () => {
     expect(rewriteHref("CONTRIBUTING.md", "README.md", "/preview/pr-42/")).toBe(
       "https://github.com/kellerlabs/homeracker/blob/main/CONTRIBUTING.md",


### PR DESCRIPTION
## 📌 What

The site can now be built and served from any mount point, not just `/`. `SITE_BASE` sets it, defaulting to `/` so production output is unchanged.

Every internal link and public asset reference goes through `import.meta.env.BASE_URL`, and pages built under a non-root base carry `robots: noindex, nofollow`.

## 🤔 Why

Groundwork for per-PR preview deployments at `homeracker.org/preview/pr-<n>/`. Thirteen root-absolute references assumed the site owned `/`, and under a subpath the configurator would have quietly dropped to schematic boxes instead of real meshes, which is exactly what a preview needs to show.

## 🔧 How

```sh
cd site
SITE_BASE=/preview/pr-999/ npm run build   # subpath build
npm run build                              # unchanged production build
```

`rewriteHref` in `src/lib/links.ts` takes `base` as a third parameter, defaulting to `/`. `src/lib/rehype.ts` reads `process.env.SITE_BASE` rather than `import.meta.env.BASE_URL`, because rehype plugins run in Node during the build rather than in the client bundle Vite injects `BASE_URL` into.

`build:site` is a new script running `astro build` alone, so CI can skip the OpenSCAD export on a parts cache hit.

<details>
<summary>Local verification</summary>

Both variants built and served together in the layout Pages will deploy, production at the root with the preview nested inside it.

| Check | Result |
|---|---|
| All 10 routes across both trees | 200 |
| Root-absolute links left in preview HTML | none |
| README links rewritten by rehype | `/preview/pr-999/models/core/` |
| Bundled `partsUrl` in preview JS | `preview/pr-999/parts/` |
| `robots: noindex` | preview only, absent at root |
| Production output | `/models/`, `/configurator/`, `/favicon.ico` unchanged |
| `npm run check` | 0 errors, 15 tests pass |

The configurator renders real part meshes under the preview base, confirming `partsUrl` resolves.

</details>

## 📚 References

- Follow-up PR adds `preview.yml` and the collection step in `pages.yml`.
