### PR TITLE
feat(ci): deploy a preview of each pull request to GitHub Pages

### DIFF
--- a/.github/actions/build-site/action.yml
+++ b/.github/actions/build-site/action.yml
@@ -1,0 +1,58 @@
+---
+name: Build Site
+description: >
+  Export the OpenSCAD part meshes (cached on the model sources) and build the Astro site
+  into site/dist. Requires the repository to be checked out already.
+
+inputs:
+  base:
+    description: >
+      Mount point for the build, with leading and trailing slash (e.g. /preview/pr-42/).
+      Defaults to the site root.
+    required: false
+    default: /
+
+runs:
+  using: composite
+  steps:
+    - name: Setup OpenSCAD
+      uses: ./.github/actions/setup-openscad
+      with:
+        scadm-source: cmd/scadm
+
+    - name: Setup Node
+      uses: actions/setup-node@v7
+      with:
+        node-version: 24
+        cache: npm
+        cache-dependency-path: site/package-lock.json
+
+    - name: Restore part meshes
+      id: parts
+      uses: actions/cache@v6
+      with:
+        path: site/public/parts
+        key: parts-${{ hashFiles('models/**/*.scad', 'site/scripts/scad/*.scad', 'site/scripts/export-parts.mjs') }}
+
+    - name: Install dependencies
+      shell: bash
+      working-directory: site
+      run: npm ci
+
+    # Several minutes of OpenSCAD on a miss, skipped entirely on a hit. PARTS_REQUIRED makes a
+    # missing OpenSCAD fatal rather than silently dropping the site to schematic boxes.
+    - name: Export part meshes
+      if: steps.parts.outputs.cache-hit != 'true'
+      shell: bash
+      working-directory: site
+      env:
+        PARTS_REQUIRED: "1"
+      run: npm run parts
+
+    - name: Build site
+      shell: bash
+      working-directory: site
+      env:
+        SITE_BASE: ${{ inputs.base }}
+      run: npm run build:site
+...

--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -6,11 +6,6 @@ on:
     branches:
       - main
   workflow_dispatch:
-    inputs:
-      preview_pr:
-        description: PR number whose preview this deployment publishes
-        required: false
-        type: string
 
 concurrency:
   group: pages
@@ -27,6 +22,8 @@ jobs:
       # still qualifies. An explicit permissions block sets every scope it omits to none.
       actions: read
       pull-requests: read
+    outputs:
+      previews: ${{ steps.collect.outputs.previews }}
     steps:
       - name: Checkout repository
         uses: actions/checkout@v7
@@ -40,11 +37,13 @@ jobs:
       # Every live preview is re-collected from scratch on each deployment, so a cancelled run
       # loses nothing and a preview that no longer qualifies is pruned here.
       - name: Collect PR previews
+        id: collect
         env:
           GH_TOKEN: ${{ github.token }}
           REPO: ${{ github.repository }}
         run: |
           set -euo pipefail
+          published=""
           # Artifacts come back newest first, so the first sighting of a name is the current one.
           gh api --paginate "repos/$REPO/actions/artifacts" \
             --jq '.artifacts[] | select(.expired == false) | select(.name | startswith("preview-pr-")) | "\(.name) \(.id)"' \
@@ -65,7 +64,9 @@ jobs:
               "https://api.github.com/repos/$REPO/actions/artifacts/$id/zip"
             mkdir -p "site/dist/preview/pr-$pr"
             unzip -q "$name.zip" -d "site/dist/preview/pr-$pr"
+            published="$published $pr"
           done < artifacts.txt
+          echo "previews=$(echo "$published" | xargs)" >> "$GITHUB_OUTPUT"
 
       - name: Upload Pages artifact
         uses: actions/upload-pages-artifact@v5
@@ -87,26 +88,32 @@ jobs:
         uses: actions/deploy-pages@v5
 
   comment:
-    needs: deploy
-    if: inputs.preview_pr != ''
+    needs: [build, deploy]
+    if: needs.build.outputs.previews != ''
     runs-on: ubuntu-latest
     permissions:
       pull-requests: write
     steps:
-      # One comment per PR, edited in place, so a busy branch does not stack up links.
-      - name: Post the preview link
+      # One comment per PR, left alone once it says the right thing, so a busy branch neither
+      # stacks up links nor collects an edit history of identical bodies.
+      - name: Post the preview links
         env:
           GH_TOKEN: ${{ github.token }}
           REPO: ${{ github.repository }}
-          PR: ${{ inputs.preview_pr }}
+          PREVIEWS: ${{ needs.build.outputs.previews }}
         run: |
           set -euo pipefail
-          body=$(printf '%s\n🔭 **Preview:** https://homeracker.org/preview/pr-%s/\n\nRebuilt on every push, removed when this PR closes.' '<!-- preview-url -->' "$PR")
-          existing=$(gh api "repos/$REPO/issues/$PR/comments" \
-            --jq 'map(select(.body | startswith("<!-- preview-url -->"))) | first | .id // empty')
-          if [ -n "$existing" ]; then
-            gh api -X PATCH "repos/$REPO/issues/comments/$existing" -f body="$body" --silent
-          else
-            gh api -X POST "repos/$REPO/issues/$PR/comments" -f body="$body" --silent
-          fi
+          for pr in $PREVIEWS; do
+            url="https://homeracker.org/preview/pr-$pr/"
+            # Surfaces the live set on the run page, so a deployment says what it published.
+            echo "::notice title=Preview pr-$pr::$url"
+            body=$(printf '%s\n🔭 **Preview:** %s\n\nRebuilt on every push, removed when this PR closes.' '<!-- preview-url -->' "$url")
+            existing=$(gh api "repos/$REPO/issues/$pr/comments" \
+              --jq 'map(select(.body | startswith("<!-- preview-url -->"))) | first | .id // empty')
+            if [ -z "$existing" ]; then
+              gh api -X POST "repos/$REPO/issues/$pr/comments" -f body="$body" --silent
+            elif [ "$(gh api "repos/$REPO/issues/comments/$existing" --jq .body)" != "$body" ]; then
+              gh api -X PATCH "repos/$REPO/issues/comments/$existing" -f body="$body" --silent
+            fi
+          done
 ...

--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -12,12 +12,6 @@ on:
         required: false
         type: string
 
-permissions:
-  contents: read
-  pages: write
-  id-token: write
-  pull-requests: write
-
 concurrency:
   group: pages
   cancel-in-progress: true
@@ -25,6 +19,14 @@ concurrency:
 jobs:
   build:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pages: write
+      id-token: write
+      # Listing and downloading the preview artifacts, and checking whether each one's PR
+      # still qualifies. An explicit permissions block sets every scope it omits to none.
+      actions: read
+      pull-requests: read
     steps:
       - name: Checkout repository
         uses: actions/checkout@v7
@@ -73,6 +75,9 @@ jobs:
   deploy:
     needs: build
     runs-on: ubuntu-latest
+    permissions:
+      pages: write
+      id-token: write
     environment:
       name: github-pages
       url: ${{ steps.deployment.outputs.page_url }}

--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -6,11 +6,17 @@ on:
     branches:
       - main
   workflow_dispatch:
+    inputs:
+      preview_pr:
+        description: PR number whose preview this deployment publishes
+        required: false
+        type: string
 
 permissions:
   contents: read
   pages: write
   id-token: write
+  pull-requests: write
 
 concurrency:
   group: pages
@@ -26,25 +32,38 @@ jobs:
       - name: Configure Pages
         uses: actions/configure-pages@v6
 
-      - name: Setup Node
-        uses: actions/setup-node@v7
-        with:
-          node-version: 24
-          cache: npm
-          cache-dependency-path: site/package-lock.json
-
-      - name: Setup OpenSCAD
-        uses: ./.github/actions/setup-openscad
-        with:
-          scadm-source: cmd/scadm
-
       - name: Build site
-        working-directory: site
+        uses: ./.github/actions/build-site
+
+      # Every live preview is re-collected from scratch on each deployment, so a cancelled run
+      # loses nothing and a preview that no longer qualifies is pruned here.
+      - name: Collect PR previews
         env:
-          PARTS_REQUIRED: "1"
+          GH_TOKEN: ${{ github.token }}
+          REPO: ${{ github.repository }}
         run: |
-          npm ci
-          npm run build
+          set -euo pipefail
+          # Artifacts come back newest first, so the first sighting of a name is the current one.
+          gh api --paginate "repos/$REPO/actions/artifacts" \
+            --jq '.artifacts[] | select(.expired == false) | select(.name | startswith("preview-pr-")) | "\(.name) \(.id)"' \
+            | awk '!seen[$1]++' > artifacts.txt
+          while read -r name id; do
+            pr="${name#preview-pr-}"
+            qualifies=$(gh pr view "$pr" --repo "$REPO" --json state,labels,files --jq '
+              if .state != "OPEN" then "no"
+              elif ([.files[].path] | any(startswith("site/") or startswith("configurator/"))) then "yes"
+              elif ([.labels[].name] | index("deploy-preview")) then "yes"
+              else "no" end' 2>/dev/null || echo "no")
+            if [ "$qualifies" != "yes" ]; then
+              echo "prune $name"
+              continue
+            fi
+            echo "publish $name"
+            curl -sSL -H "Authorization: Bearer $GH_TOKEN" -o "$name.zip" \
+              "https://api.github.com/repos/$REPO/actions/artifacts/$id/zip"
+            mkdir -p "site/dist/preview/pr-$pr"
+            unzip -q "$name.zip" -d "site/dist/preview/pr-$pr"
+          done < artifacts.txt
 
       - name: Upload Pages artifact
         uses: actions/upload-pages-artifact@v5
@@ -61,4 +80,28 @@ jobs:
       - name: Deploy to GitHub Pages
         id: deployment
         uses: actions/deploy-pages@v5
+
+  comment:
+    needs: deploy
+    if: inputs.preview_pr != ''
+    runs-on: ubuntu-latest
+    permissions:
+      pull-requests: write
+    steps:
+      # One comment per PR, edited in place, so a busy branch does not stack up links.
+      - name: Post the preview link
+        env:
+          GH_TOKEN: ${{ github.token }}
+          REPO: ${{ github.repository }}
+          PR: ${{ inputs.preview_pr }}
+        run: |
+          set -euo pipefail
+          body=$(printf '%s\n🔭 **Preview:** https://homeracker.org/preview/pr-%s/\n\nRebuilt on every push, removed when this PR closes.' '<!-- preview-url -->' "$PR")
+          existing=$(gh api "repos/$REPO/issues/$PR/comments" \
+            --jq 'map(select(.body | startswith("<!-- preview-url -->"))) | first | .id // empty')
+          if [ -n "$existing" ]; then
+            gh api -X PATCH "repos/$REPO/issues/comments/$existing" -f body="$body" --silent
+          else
+            gh api -X POST "repos/$REPO/issues/$PR/comments" -f body="$body" --silent
+          fi
 ...

--- a/.github/workflows/preview.yml
+++ b/.github/workflows/preview.yml
@@ -1,0 +1,73 @@
+---
+name: Preview
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened, labeled]
+
+concurrency:
+  group: preview-${{ github.event.number }}
+  cancel-in-progress: true
+
+jobs:
+  gate:
+    # A preview publishes this PR's own HTML and JS on homeracker.org, same-origin with the live
+    # site, so a fork must never reach that path. The repository's fork-approval setting only
+    # holds back first-time contributors and is not a sufficient gate on its own.
+    if: github.event.pull_request.head.repo.full_name == github.repository
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: read
+    outputs:
+      build: ${{ steps.decide.outputs.build }}
+    steps:
+      - name: Decide whether this PR gets a preview
+        id: decide
+        env:
+          GH_TOKEN: ${{ github.token }}
+          REPO: ${{ github.repository }}
+          PR: ${{ github.event.number }}
+          LABELLED: ${{ contains(github.event.pull_request.labels.*.name, 'deploy-preview') }}
+        run: |
+          set -euo pipefail
+          if gh pr diff "$PR" --repo "$REPO" --name-only | grep -qE '^(site|configurator)/'; then
+            echo "build=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "build=$LABELLED" >> "$GITHUB_OUTPUT"
+          fi
+
+  build:
+    needs: gate
+    if: needs.gate.outputs.build == 'true'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      actions: write
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v7
+
+      - name: Build site
+        uses: ./.github/actions/build-site
+        with:
+          base: /preview/pr-${{ github.event.number }}/
+
+      - name: Upload preview
+        uses: actions/upload-artifact@v7
+        with:
+          name: preview-pr-${{ github.event.number }}
+          path: site/dist
+          retention-days: 14
+
+      # Pages serves one artifact for the whole domain, so publishing a preview means
+      # redeploying the site with every live preview collected into it.
+      - name: Trigger the Pages deployment
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          gh workflow run pages.yml \
+            --repo "${{ github.repository }}" \
+            --ref main \
+            -f preview_pr="${{ github.event.number }}"
+...

--- a/.github/workflows/preview.yml
+++ b/.github/workflows/preview.yml
@@ -61,13 +61,13 @@ jobs:
           retention-days: 14
 
       # Pages serves one artifact for the whole domain, so publishing a preview means
-      # redeploying the site with every live preview collected into it.
+      # redeploying the site with every live preview collected into it. The dispatch carries no
+      # inputs: it runs main's workflow, which finds this artifact by name on its own.
       - name: Trigger the Pages deployment
         env:
           GH_TOKEN: ${{ github.token }}
         run: |
           gh workflow run pages.yml \
             --repo "${{ github.repository }}" \
-            --ref main \
-            -f preview_pr="${{ github.event.number }}"
+            --ref main
 ...

--- a/.github/workflows/preview.yml
+++ b/.github/workflows/preview.yml
@@ -3,7 +3,7 @@ name: Preview
 
 on:
   pull_request:
-    types: [opened, synchronize, reopened, labeled]
+    types: [opened, synchronize, reopened, labeled, unlabeled, closed]
 
 concurrency:
   group: preview-${{ github.event.number }}
@@ -14,7 +14,10 @@ jobs:
     # A preview publishes this PR's own HTML and JS on homeracker.org, same-origin with the live
     # site, so a fork must never reach that path. The repository's fork-approval setting only
     # holds back first-time contributors and is not a sufficient gate on its own.
-    if: github.event.pull_request.head.repo.full_name == github.repository
+    if: >-
+      github.event.pull_request.head.repo.full_name == github.repository
+      && github.event.action != 'closed'
+      && github.event.action != 'unlabeled'
     runs-on: ubuntu-latest
     permissions:
       contents: read
@@ -67,7 +70,34 @@ jobs:
         env:
           GH_TOKEN: ${{ github.token }}
         run: |
+          set -euo pipefail
           gh workflow run pages.yml \
             --repo "${{ github.repository }}" \
             --ref main
+
+  # Closing a PR or dropping its label leaves its preview published until something redeploys.
+  # pages.yml re-evaluates every artifact on each run, so a deployment is all the pruning takes.
+  prune:
+    if: >-
+      github.event.pull_request.head.repo.full_name == github.repository
+      && (github.event.action == 'closed'
+      || (github.event.action == 'unlabeled' && github.event.label.name == 'deploy-preview'))
+    runs-on: ubuntu-latest
+    permissions:
+      actions: write
+    steps:
+      - name: Redeploy only if this PR had a preview
+        env:
+          GH_TOKEN: ${{ github.token }}
+          REPO: ${{ github.repository }}
+          PR: ${{ github.event.number }}
+        run: |
+          set -euo pipefail
+          found=$(gh api --paginate "repos/$REPO/actions/artifacts" \
+            --jq "[.artifacts[] | select(.expired == false) | select(.name == \"preview-pr-$PR\")] | length")
+          if [ "$found" -eq 0 ]; then
+            echo "no preview artifact for pr-$PR, nothing to prune"
+            exit 0
+          fi
+          gh workflow run pages.yml --repo "$REPO" --ref main
 ...

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -215,6 +215,21 @@ Releases are automated using Camunda's GitHub actions from [infra-global-github-
 5. Push: `git push origin feature/my-feature`
 6. Create PR with description and screenshots
 
+### 🔭 Preview Deployments
+
+A PR touching `site/` or `configurator/` is published at `https://homeracker.org/preview/pr-<number>/` and a bot comments the link. It rebuilds on every push and disappears when the PR closes.
+
+To preview a PR that touches neither path, add the `deploy-preview` label (e.g. if you want to see your new model in the catalog).
+
+Previews come from branches in this repository only. A PR from a fork never gets one, because a preview serves its author's HTML and JavaScript from the live domain.
+
+Since previews are served from a subpath, never write a root-absolute internal link. Use `import.meta.env.BASE_URL` in components and client scripts, and pass the base explicitly into anything that runs at build time in Node, such as the rehype plugins in `site/src/lib/`. To check a subpath build locally:
+
+```sh
+cd site
+SITE_BASE=/preview/pr-999/ npm run build
+```
+
 ## 📂 Project Structure
 
 ```


### PR DESCRIPTION
## 📌 What

Every PR touching `site/` or `configurator/` gets published at `https://homeracker.org/preview/pr-<number>/`, with a bot comment carrying the link. The `deploy-preview` label forces one on a PR that touches neither path.

Builds from this repository only. A fork never gets a preview.

## 🤔 Why

Reviewing a site change meant checking out the branch and building locally, which needs OpenSCAD and several minutes. Now it is a URL.

Pages serves one artifact for the whole domain, so production and every live preview have to ship in a single deployment. `preview.yml` builds a PR and uploads it as an artifact; `pages.yml` rebuilds production and collects every qualifying preview into `preview/pr-<n>/` before deploying.

## 🔧 How

`preview.yml` gates in three steps: fork PRs are rejected outright, a diff touching `site/` or `configurator/` builds, and anything else builds only when labelled. It then triggers `pages.yml` directly via `workflow_dispatch` rather than `workflow_run`, because a `workflow_run` hook fires whenever `Preview` completes, and a skipped build still completes successfully, so every unrelated PR push would have redeployed the whole site.

`pages.yml` re-collects previews from scratch on every deployment. A preview whose PR has closed, or which no longer qualifies, is pruned there. That also makes `cancel-in-progress` safe, since a cancelled run loses nothing.

The six build steps the two workflows shared now live in `.github/actions/build-site`, a composite action taking a `base` input. Part meshes are cached on a hash of the `.scad` sources, so a preview build reuses the library production just built.

## ⚙️ Repo setup

The `deploy-preview` label must exist. Pages is already on the Actions source, so nothing else changes.

Two things only the first real run can confirm: `build-site` nesting a local composite action inside another, and `preview.yml` requesting `actions: write` on a repository whose default workflow permission is read. Both fail loudly rather than silently.

<details>
<summary>Shell logic verified against live data</summary>

The gate and collection queries were run against real PRs rather than assumed.

| Query | Result |
|---|---|
| gate on a PR touching `site/` | `build` |
| gate on a renovate-only PR | `label-only` |
| qualifies: open+site / open+unrelated / closed | `yes` / `no` / `no` |
| artifact listing, none present | empty, exit 0 |
| comment-marker lookup, none present | empty, exit 0 |

`actionlint` and `yamllint` pass.

</details>

## 📚 References

- [CONTRIBUTING.md](CONTRIBUTING.md) — preview deployments section
- #471 made the site base-aware, which this depends on
