### PR TITLE
fix(ci): skip the prune dispatch when a PR is merged

### DIFF
--- a/.github/workflows/preview.yml
+++ b/.github/workflows/preview.yml
@@ -77,10 +77,14 @@ jobs:
 
   # Closing a PR or dropping its label leaves its preview published until something redeploys.
   # pages.yml re-evaluates every artifact on each run, so a deployment is all the pruning takes.
+  #
+  # A merge is excluded: it pushes to main, which deploys anyway. Dispatching here as well would
+  # land seconds later and cancel that push run under the shared `pages` concurrency group,
+  # marking the merge commit as failed even though the site deployed fine.
   prune:
     if: >-
       github.event.pull_request.head.repo.full_name == github.repository
-      && (github.event.action == 'closed'
+      && ((github.event.action == 'closed' && !github.event.pull_request.merged)
       || (github.event.action == 'unlabeled' && github.event.label.name == 'deploy-preview'))
     runs-on: ubuntu-latest
     permissions:


### PR DESCRIPTION
## 📌 What

The `prune` job no longer dispatches a deployment when a PR is closed by being merged.

## 🤔 Why

A merge pushes to `main`, which already deploys and prunes the merged PR's preview. Dispatching as well landed a second run about five seconds later, and the shared `pages` concurrency group cancelled the push run in favour of it.

The site deployed correctly either way, but the cancelled run is the one attached to the merge commit, so `main` showed a red cross on the repository home page. Merging #472 did exactly this.

Closing a PR without merging still dispatches, because nothing pushes in that case.

## 🔧 How

`!github.event.pull_request.merged` on the `closed` arm of the job condition. The `unlabeled` arm is untouched.

`cancel-in-progress: false` would also have stopped the cancellation, but it would queue a full deployment per preview push rather than collapsing rapid ones, and it treats the symptom rather than the redundant dispatch.

This does not make the race impossible. A push to `main` within seconds of a preview build finishing could still be cancelled by that build's dispatch. That is situational, where the merge case fired every time, and `concurrency` has no way to express "a dispatch must never cancel a push".

## 📚 References

- #472 introduced the preview deployments
