### PR TITLE
feat(ci): pin every action to a commit SHA and enforce it with zizmor

### DIFF
--- a/.github/actions/build-site/action.yml
+++ b/.github/actions/build-site/action.yml
@@ -21,7 +21,7 @@ runs:
         scadm-source: cmd/scadm
 
     - name: Setup Node
-      uses: actions/setup-node@v7
+      uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
       with:
         node-version: 24
         cache: npm
@@ -29,7 +29,7 @@ runs:
 
     - name: Restore part meshes
       id: parts
-      uses: actions/cache@v6
+      uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
       with:
         path: site/public/parts
         key: parts-${{ hashFiles('models/**/*.scad', 'site/scripts/scad/*.scad', 'site/scripts/export-parts.mjs') }}

--- a/.github/actions/setup-openscad/action.yml
+++ b/.github/actions/setup-openscad/action.yml
@@ -25,7 +25,7 @@ runs:
   using: composite
   steps:
     - name: Set up Python
-      uses: actions/setup-python@v7
+      uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
       with:
         python-version: '3.14'
 
@@ -65,7 +65,7 @@ runs:
         fi
 
     - name: Cache OpenSCAD and libraries
-      uses: actions/cache@v6
+      uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
       with:
         path: bin/openscad
         key: openscad-${{ runner.os }}-${{ steps.resolve-scadm.outputs.version }}-${{ hashFiles('scadm.json') }}

--- a/.github/workflows/automerge-release.yml
+++ b/.github/workflows/automerge-release.yml
@@ -15,7 +15,7 @@ jobs:
     steps:
       - name: Generate GitHub App Token
         id: app-token
-        uses: actions/create-github-app-token@v3.2.0
+        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
         with:
           client-id: ${{ secrets.RELEASES_APP_ID }}
           private-key: ${{ secrets.RELEASES_APP_PRIVATE_KEY }}

--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -21,10 +21,10 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       - name: Set up Python
-        uses: actions/setup-python@v7
+        uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
         with:
           python-version: '3.14'
 
@@ -40,7 +40,7 @@ jobs:
 
       - name: Install Mesa3D (Windows software OpenGL)
         if: runner.os == 'Windows'
-        uses: ssciwr/setup-mesa-dist-win@v3
+        uses: ssciwr/setup-mesa-dist-win@2dfeaebfa514f74c2b8cd8d27108c31486d33e72 # v3.0.0
 
       - name: Run integration tests
         shell: bash

--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -26,10 +26,10 @@ jobs:
       previews: ${{ steps.collect.outputs.previews }}
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       - name: Configure Pages
-        uses: actions/configure-pages@v6
+        uses: actions/configure-pages@45bfe0192ca1faeb007ade9deae92b16b8254a0d # v6.0.0
 
       - name: Build site
         uses: ./.github/actions/build-site
@@ -69,7 +69,7 @@ jobs:
           echo "previews=$(echo "$published" | xargs)" >> "$GITHUB_OUTPUT"
 
       - name: Upload Pages artifact
-        uses: actions/upload-pages-artifact@v5
+        uses: actions/upload-pages-artifact@fc324d3547104276b827a68afc52ff2a11cc49c9 # v5.0.0
         with:
           path: site/dist
 
@@ -85,7 +85,7 @@ jobs:
     steps:
       - name: Deploy to GitHub Pages
         id: deployment
-        uses: actions/deploy-pages@v5
+        uses: actions/deploy-pages@368f82528645a54fb793d4d04e342629a3f51346 # v5.0.1
 
   comment:
     needs: [build, deploy]

--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -14,7 +14,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       - name: Setup OpenSCAD
         uses: ./.github/actions/setup-openscad
@@ -22,7 +22,7 @@ jobs:
           scadm-source: cmd/scadm
 
       - name: Cache flatten checksums
-        uses: actions/cache@v6
+        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
         with:
           path: models/.flatten-checksums
           key: flatten-checksums-${{ github.head_ref || github.ref_name }}
@@ -33,7 +33,7 @@ jobs:
         run: pip install pytest -r requirements.txt
 
       - name: Setup Node
-        uses: actions/setup-node@v7
+        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:
           node-version: 24
           cache: npm
@@ -42,4 +42,4 @@ jobs:
             site/package-lock.json
 
       - name: Run pre-commit
-        uses: pre-commit/action@v3.0.1
+        uses: pre-commit/action@2c7b3805fd2a0fd8c1884dcaebf91fc102a13ecd # v3.0.1

--- a/.github/workflows/preview.yml
+++ b/.github/workflows/preview.yml
@@ -49,7 +49,7 @@ jobs:
       actions: write
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       - name: Build site
         uses: ./.github/actions/build-site
@@ -57,7 +57,7 @@ jobs:
           base: /preview/pr-${{ github.event.number }}/
 
       - name: Upload preview
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: preview-pr-${{ github.event.number }}
           path: site/dist

--- a/.github/workflows/publish-scadm.yml
+++ b/.github/workflows/publish-scadm.yml
@@ -22,10 +22,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       - name: Set up Python
-        uses: actions/setup-python@v7
+        uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
         with:
           python-version: '3.14'
 
@@ -44,7 +44,7 @@ jobs:
 
       - name: Publish to PyPI
         if: ${{ !inputs.dry_run }}
-        uses: pypa/gh-action-pypi-publish@release/v1
+        uses: pypa/gh-action-pypi-publish@dc37677b2e1c63e2034f94d8a5b11f265b73ba33 # v1.14.2
         with:
           packages-dir: cmd/scadm/dist/
           print-hash: true

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -14,12 +14,12 @@ jobs:
     steps:
       - name: Generate GitHub App Token
         id: app-token
-        uses: actions/create-github-app-token@v3.2.0
+        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
         with:
           client-id: ${{ secrets.RELEASES_APP_ID }}
           private-key: ${{ secrets.RELEASES_APP_PRIVATE_KEY }}
 
       - name: Handle Release Creation
-        uses: camunda/infra-global-github-actions/teams/infra/pull-request/release@pull-request-1.0.3
+        uses: camunda/infra-global-github-actions/teams/infra/pull-request/release@67d00e9260887361a31f6446252fffbecae4a02e # pull-request-1.0.3
         with:
           github-token: ${{ steps.app-token.outputs.token }}

--- a/.github/workflows/test-setup-openscad.yml
+++ b/.github/workflows/test-setup-openscad.yml
@@ -44,7 +44,7 @@ jobs:
     name: test (${{ matrix.name }})
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       - name: Create test requirements file
         if: matrix.name == 'scadm-requirements'

--- a/.github/workflows/validate-models.yml
+++ b/.github/workflows/validate-models.yml
@@ -18,7 +18,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       - name: Setup OpenSCAD
         uses: ./.github/actions/setup-openscad
@@ -32,7 +32,7 @@ jobs:
 
       - name: Upload logs on failure
         if: failure()
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: render-logs
           path: /tmp/*.log

--- a/.github/workflows/validate-pr-title.yml
+++ b/.github/workflows/validate-pr-title.yml
@@ -13,7 +13,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Validate PR title
-        uses: camunda/infra-global-github-actions/teams/infra/pull-request/validate-title@pull-request-1.0.3
+        uses: camunda/infra-global-github-actions/teams/infra/pull-request/validate-title@67d00e9260887361a31f6446252fffbecae4a02e # pull-request-1.0.3
         with:
           # Keep in sync with .github/config/release-please-config.json changelog-sections
           types: |

--- a/.github/workflows/web.yml
+++ b/.github/workflows/web.yml
@@ -29,10 +29,10 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       - name: Setup Node
-        uses: actions/setup-node@v7
+        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:
           node-version: 24
           cache: npm
@@ -60,7 +60,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       - name: Setup OpenSCAD
         uses: ./.github/actions/setup-openscad
@@ -68,7 +68,7 @@ jobs:
           scadm-source: cmd/scadm
 
       - name: Setup Node
-        uses: actions/setup-node@v7
+        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:
           node-version: 24
           cache: npm

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -10,6 +10,12 @@ repos:
     rev: v1.7.12
     hooks:
       - id: actionlint
+  # Fails on any action reference that is not pinned to a full commit SHA. Its other audits are
+  # switched off for now; see zizmor.yml.
+  - repo: https://github.com/zizmorcore/zizmor-pre-commit
+    rev: v1.30.0
+    hooks:
+      - id: zizmor
   - repo: https://github.com/psf/black
     rev: 26.5.1
     hooks:

--- a/renovate.json5
+++ b/renovate.json5
@@ -3,6 +3,9 @@
   "extends": [
     "config:recommended",
     ":enablePreCommit",
+    // Keeps every action reference on a full commit SHA. A tag is a moving target an upstream
+    // owner can repoint at any time; a digest cannot be changed under us.
+    "helpers:pinGitHubActionDigests",
     "local>kellerlabs/homeracker:renovate-dependencies.json"
   ],
   // Ignore any repository config presets
@@ -20,6 +23,24 @@
   "minimumReleaseAgeBehaviour": "timestamp-optional",
   // Without this, an update that has not served its five days still gets a branch and a PR.
   "internalChecksFilter": "strict",
+  "customManagers": [
+    {
+      // Sub-actions of infra-global-github-actions are released under a per-action tag
+      // ("pull-request-1.0.3"). The built-in github-actions manager drops the sub-action path
+      // from depName, so it cannot tell those tag families apart and silently stops finding
+      // releases. Matching the pinned digest and its version comment restores that.
+      "description": "Track camunda/infra-global-github-actions sub-actions pinned to a per-action release tag",
+      "customType": "regex",
+      "managerFilePatterns": ["/^\\.github/.+\\.ya?ml$/"],
+      "matchStrings": [
+        "uses:\\s*camunda/infra-global-github-actions/[\\w./-]+@(?<currentDigest>[a-f0-9]{40})\\s+#\\s*(?<family>[a-z0-9-]+?)-(?<currentValue>\\d+\\.\\d+\\.\\d+)\\b"
+      ],
+      "depNameTemplate": "camunda/infra-global-github-actions/{{{family}}}",
+      "packageNameTemplate": "camunda/infra-global-github-actions",
+      "datasourceTemplate": "github-tags",
+      "extractVersionTemplate": "^{{{family}}}-(?<version>\\d+\\.\\d+\\.\\d+)$"
+    }
+  ],
   "schedule": ["* * * * 0,6"],
   // Use "deps" as commit type instead of "chore(deps)"
   "semanticCommits": "enabled",
@@ -60,9 +81,10 @@
       "automerge": true
     },
     {
-      // infra-global-github-actions uses per-component semver tags (e.g. pull-request-1.0.0)
+      // The custom manager strips the per-action tag prefix, so these arrive as plain semver
+      // and need no versioning override. Matching on packageName covers both the sub-action
+      // depNames the custom manager emits and any bare reference to the repository.
       "matchPackageNames": ["camunda/infra-global-github-actions"],
-      "versioning": "regex:^pull-request-(?<major>\\d+)\\.(?<minor>\\d+)\\.(?<patch>\\d+)$",
       "automerge": true
     },
     {

--- a/zizmor.yml
+++ b/zizmor.yml
@@ -1,0 +1,17 @@
+---
+# zizmor is here for one job right now: every action reference must be a full commit SHA.
+# The `unpinned-uses` audit stays on and applies to every org without exception, including
+# actions/* and camunda/*, because a tag is a moving target its owner can repoint at any time.
+#
+# The audits below are switched off because the repository has a pre-existing backlog of
+# findings under them, not because they are wrong. Re-enable them one at a time as that backlog
+# is worked through, rather than in bulk.
+rules:
+  template-injection:
+    disable: true
+  artipacked:
+    disable: true
+  self-repository:
+    disable: true
+  github-app:
+    disable: true


### PR DESCRIPTION
## 📌 What

All 14 external action references are pinned to a full commit SHA with a full semver comment. `zizmor` enforces it as a pre-commit hook, and Renovate keeps the digests current.

No org is exempt. `actions/*` and `camunda/*` are pinned like everything else.

## 🤔 Why

A tag is a moving target its owner can repoint at any time, so a tag reference is an open door into every workflow that uses it. A digest cannot be changed underneath us.

`pypa/gh-action-pypi-publish@release/v1` was the sharpest case: a mutable branch rather than even a tag, running with the PyPI publish credentials.

## 🔧 How

`zizmor.yml` keeps the `unpinned-uses` audit on and switches off the four audits with a pre-existing backlog. Those are tracked separately in #474 and should come back one at a time, not in bulk.

`helpers:pinGitHubActionDigests` makes Renovate pin anything new automatically and keep the version comments in step.

A custom Renovate manager tracks the `infra-global-github-actions` sub-actions. The built-in `github-actions` manager drops the sub-action path from `depName`, so it cannot tell tag families like `pull-request-1.0.3` apart and silently stops finding releases. The manager keys on the digest and its version comment instead, using `family` as the discriminator.

The old `versioning: "regex:^pull-request-..."` override is removed with it. `extractVersionTemplate` already strips the prefix, so Renovate now sees plain `1.0.3`, and keeping the regex would have made every version fail to parse.

<details>
<summary>Verification</summary>

`zizmor` enforces rather than passing vacuously. Unpinning one `checkout` and re-running:

```
clean:              No findings to report. Good job! (43 suppressed)
checkout unpinned:  error[unpinned-uses]: unpinned action reference -> 1 high
restored:           No findings to report.
```

The custom manager regex against the real references:

```
release-please.yml     -> pull-request 1.0.3 67d00e926088
validate-pr-title.yml  -> pull-request 1.0.3 67d00e926088
```

`pre-commit run --all-files` and `renovate-config-validator` both pass.

</details>
